### PR TITLE
Resolved #4: Handles multi-byte characters with url-retrieve (i.e., without the external curl command)

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -417,16 +417,15 @@ INFO is a plist with the following keys:
       (if-let* ((status (buffer-substring (line-beginning-position) (line-end-position)))
                 (json-object-type 'plist)
                 (response (progn (forward-paragraph)
-                                 (condition-case nil
-                                         (json-read)
-                                       (json-readtable-error 'json-read-error)))))
+                                 (let ((json-str (decode-coding-string
+                                                  (buffer-substring-no-properties (point) (point-max))
+                                                  'utf-8)))
+                                   (condition-case nil
+                                       (json-read-from-string json-str)
+                                     (json-readtable-error 'json-read-error))))))
           (cond
            ((string-match-p "200 OK" status)
-            (list :content (string-trim
-                            (decode-coding-string
-                             (map-nested-elt
-                              response '(:choices 0 :message :content))
-                             'utf-8))
+            (list :content (string-trim (map-nested-elt response '(:choices 0 :message :content)))
                   :status status))
            ((plist-get response :error)
             (let* ((error-plist (plist-get response :error))

--- a/gptel.el
+++ b/gptel.el
@@ -202,7 +202,9 @@ By default, \"openai.com\" is used as HOST and \"apikey\" as USER."
                                     :host (or host "openai.com")
                                     :user (or user "apikey")))
                               :secret)))
-      (if (functionp secret) (funcall secret) secret)
+      (if (functionp secret)
+          (encode-coding-string (funcall secret) 'utf-8)
+        secret)
     (user-error "No `gptel-api-key' found in the auth source")))
 
 (defun gptel--api-key ()


### PR DESCRIPTION
These two commits fix handling of multi-byte characters in the prompt send to OpenAI and in the response received from it.

As a result, you can now use non-Latin alphabets like Greek, or emojis.

To make requests work, it was necessary to encode the loaded API key as utf-8, for reasons that remain obscure, but may have to do with some subtlety concerning how the `concat` function combines multibyte and non-multibyte strings. To make replies work, it was necessary to decode the response body as utf-8 before, not after, parsing it as json.

I have tested this lightly on Emacs 28.1 running on Linux.