### PR TITLE
Make OpenAI API endpoint configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -114,6 +114,11 @@ If you want custom behavior, such as
 
 GPTel provides a general =gptel-request= function that accepts a custom prompt and a callback to act on the response. You can use this to build custom workflows not supported by =gptel-send=.  See the documentation of =gptel-request=, and the [[https://github.com/karthink/gptel/wiki][wiki]] for examples.
 
+** Additional Configuration
+
+- You can override the OpenAI API endpoint by customizing ~gptel-openai-endpoint~.
+
+
 ** Why another ChatGPT client?
 
 Existing Emacs clients don't /reliably/ let me use it the simple way I can in the browser.  They will get better, but I wanted something for now.

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -42,7 +42,7 @@
 PROMPTS is the data to send, TOKEN is a unique identifier."
   (let* ((args
           (list "--location" "--silent" "--compressed" "--disable"))
-         (url "https://api.openai.com/v1/chat/completions")
+         (url (concat gptel-openai-endpoint "/chat/completions"))
          (data (encode-coding-string
                 (json-encode (gptel--request-data prompts))
                 'utf-8))

--- a/gptel.el
+++ b/gptel.el
@@ -487,7 +487,7 @@ there."
   (let ((prompts-plist
          `(:model ,gptel-model
            :messages [,@prompts]
-           :stream ,(and gptel-stream gptel-use-curl))))
+           :stream ,(or (and gptel-stream gptel-use-curl) :json-false))))
     (when gptel-temperature
       (plist-put prompts-plist :temperature (gptel--numberize gptel-temperature)))
     (when gptel-max-tokens
@@ -522,6 +522,9 @@ BUFFER is the interaction buffer for ChatGPT."
     ('org-mode (gptel--convert-markdown->org content))
     (_ content)))
 
+(defcustom gptel-openai-endpoint "https://api.openai.com/v1"
+  "The OpenAI API endpoint URI, including the API version path element (string).")
+
 (defun gptel--url-get-response (info &optional callback)
   "Fetch response to prompt in INFO from ChatGPT.
 
@@ -542,7 +545,7 @@ the response is inserted into the current buffer after point."
          (encode-coding-string
           (json-encode (gptel--request-data (plist-get info :prompt)))
           'utf-8)))
-    (url-retrieve "https://api.openai.com/v1/chat/completions"
+    (url-retrieve (concat gptel-openai-endpoint "/chat/completions")
                   (lambda (_)
                     (pcase-let ((`(,response ,http-msg ,error)
                                  (gptel--url-parse-response (current-buffer))))


### PR DESCRIPTION
Also encode stream :json-false when stream is nil
since the API requires a boolean value (https://platform.openai.com/docs/api-reference/chat).

Signed-off-by: Christian Romney <christian.romney@nubank.com.br>