### PR TITLE
Make API host configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,9 +60,9 @@ Procure an [[https://platform.openai.com/account/api-keys][OpenAI API key]].
 
 Optional: Set =gptel-api-key= to the key. Alternatively, you may choose a more secure method such as:
 
-- Storing in =~/.authinfo=. By default, "openai.com" is used as HOST and "apikey" as USER.
+- Storing in =~/.authinfo=. By default, "api.openai.com" is used as HOST and "apikey" as USER.
   #+begin_src authinfo
-machine openai.com login apikey password TOKEN
+machine api.openai.com login apikey password TOKEN
   #+end_src
 - Setting it to a function that returns the key.
 
@@ -113,6 +113,10 @@ If you want custom behavior, such as
 - sending the current line only, etc,
 
 GPTel provides a general =gptel-request= function that accepts a custom prompt and a callback to act on the response. You can use this to build custom workflows not supported by =gptel-send=.  See the documentation of =gptel-request=, and the [[https://github.com/karthink/gptel/wiki][wiki]] for examples.
+
+** Additional Configuration
+
+- You can override the OpenAI API host by customizing =gptel-host=.
 
 ** Why another ChatGPT client?
 

--- a/README.org
+++ b/README.org
@@ -15,8 +15,11 @@ https://user-images.githubusercontent.com/8607532/230516816-ae4a613a-4d01-4073-a
 - Supports conversations and multiple independent sessions.
 - You can go back and edit your previous prompts, or even ChatGPT's previous responses when continuing a conversation. These will be fed back to ChatGPT.
 
-GPTel uses Curl if available, but falls back to =url-retrieve= to work without external dependencies.
-  
+GPTel uses Curl if available, but falls back to url-retrieve to work without external dependencies.
+
+** Breaking Changes
+1. =gptel-api-key-from-auth-source= search the API KEY using the =gptel-host=, i.e., "api.openai.com" instead of the original "openai.com". You need to update your =~/.authinfo=.
+
 ** Installation
 
 GPTel is on MELPA. Install it with =M-x package-install⏎= =gptel=.
@@ -116,7 +119,7 @@ GPTel provides a general =gptel-request= function that accepts a custom prompt a
 
 ** Additional Configuration
 
-- You can override the OpenAI API host by customizing =gptel-host=.
+- You can override the OpenAI API host by customizing =gptel-host=. This is useful for those who transform Azure API into OpenAI API format, utilize reverse proxy, or employ third-party proxy services for the OpenAI API.
 
 ** Why another ChatGPT client?
 

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -42,7 +42,7 @@
 PROMPTS is the data to send, TOKEN is a unique identifier."
   (let* ((args
           (list "--location" "--silent" "--compressed" "--disable"))
-         (url "https://api.openai.com/v1/chat/completions")
+         (url (format "https://%s/v1/chat/completions" gptel-host))
          (data (encode-coding-string
                 (json-encode (gptel--request-data prompts))
                 'utf-8))

--- a/gptel.el
+++ b/gptel.el
@@ -70,7 +70,7 @@
   "Interact with ChatGPT from anywhere in Emacs.")
 
 (defcustom gptel-host "api.openai.com"
-  "The API host."
+  "The API host queried by gptel."
   :group 'gptel
   :type 'string)
 

--- a/gptel.el
+++ b/gptel.el
@@ -69,6 +69,11 @@
 (defgroup gptel nil
   "Interact with ChatGPT from anywhere in Emacs.")
 
+(defcustom gptel-host "api.openai.com"
+  "The API host."
+  :group 'gptel
+  :type 'string)
+
 (defcustom gptel-api-key #'gptel-api-key-from-auth-source
   "An OpenAI API key (string).
 
@@ -214,9 +219,9 @@ To set the temperature for a chat session interactively call
 
 (defun gptel-api-key-from-auth-source (&optional host user)
   "Lookup api key in the auth source.
-By default, \"openai.com\" is used as HOST and \"apikey\" as USER."
+By default, `gptel-host' is used as HOST and \"apikey\" as USER."
   (if-let ((secret (plist-get (car (auth-source-search
-                                    :host (or host "openai.com")
+                                    :host (or host gptel-host)
                                     :user (or user "apikey")))
                               :secret)))
       (if (functionp secret)
@@ -557,7 +562,7 @@ the response is inserted into the current buffer after point."
          (encode-coding-string
           (json-encode (gptel--request-data (plist-get info :prompt)))
           'utf-8)))
-    (url-retrieve "https://api.openai.com/v1/chat/completions"
+    (url-retrieve (format "https://%s/v1/chat/completions" gptel-host)
                   (lambda (_)
                     (pcase-let ((`(,response ,http-msg ,error)
                                  (gptel--url-parse-response (current-buffer))))


### PR DESCRIPTION
This is a similar PR to https://github.com/karthink/gptel/pull/49. I submitted a new PR because:
1. @christianromney has not replied for a month
2. The API key may also be related to the host for some API proxy services like https://aiproxy.io
3. Most API proxies use the same `basePath` & `Path` as the OpenAI API, i.e. "/v1/chat/completions", so we only need to make the Host configurable.