### PR TITLE
feature/curl proxy support

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -36,6 +36,13 @@
 (defvar gptel-curl--process-alist nil
   "Alist of active GPTel curl requests.")
 
+(defcustom gptel-proxy-path ""
+  "Path to a proxy to use for gptel interactions.
+Passed to curl via --proxy arg, for example 'proxy.yourorg.com:80'
+Leave it empty if you don't use a proxy."
+  :group 'gptel
+  :type 'string)
+
 (defun gptel-curl--get-args (prompts token)
   "Produce list of arguments for calling Curl.
 
@@ -54,6 +61,12 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
     ;; (push (format "--keepalive-time %s" 240) args)
     (push (format "-m%s" 60) args)
     (push "-D-" args)
+    (when (not (string-empty-p gptel-proxy-path))
+      (push "--proxy" args)
+      (push (format "%s" gptel-proxy-path) args)
+      (push "--proxy-negotiate" args)
+      (push "--proxy-user" args)
+      (push ":" args))
     (pcase-dolist (`(,key . ,val) headers)
       (push (format "-H%s: %s" key val) args))
     (push (format "-d%s" data) args)

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -56,8 +56,8 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
            "-D-"
            (format "-d%s" data)
            url)
-     (when (not (string-empty-p gptel-proxy-path))
-       (list "--proxy" gptel-proxy-path
+     (when (not (string-empty-p gptel-proxy))
+       (list "--proxy" gptel-proxy
              "--proxy-negotiate"
              "--proxy-user" ":"))
      (cl-loop for (key . val) in headers

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -54,14 +54,14 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
            (format "-w(%s . %%{size_header})" token)
            (format "-m%s" 60)
            "-D-"
-           (format "-d%s" data)
-           url)
+           (format "-d%s" data))
      (when (not (string-empty-p gptel-proxy))
        (list "--proxy" gptel-proxy
              "--proxy-negotiate"
              "--proxy-user" ":"))
      (cl-loop for (key . val) in headers
-              collect (format "-H%s: %s" key val)))))
+              collect (format "-H%s: %s" key val))
+     (list url))))
 
 ;;TODO: The :transformer argument here is an alternate implementation of
 ;;`gptel-response-filter-functions'. The two need to be unified.

--- a/gptel.el
+++ b/gptel.el
@@ -74,7 +74,7 @@
   :group 'gptel
   :type 'string)
 
-(defcustom gptel-proxy-path ""
+(defcustom gptel-proxy ""
   "Path to a proxy to use for gptel interactions.
 Passed to curl via --proxy arg, for example \"proxy.yourorg.com:80\"
 Leave it empty if you don't use a proxy."

--- a/gptel.el
+++ b/gptel.el
@@ -74,6 +74,13 @@
   :group 'gptel
   :type 'string)
 
+(defcustom gptel-proxy-path ""
+  "Path to a proxy to use for gptel interactions.
+Passed to curl via --proxy arg, for example \"proxy.yourorg.com:80\"
+Leave it empty if you don't use a proxy."
+  :group 'gptel
+  :type 'string)
+
 (defcustom gptel-api-key #'gptel-api-key-from-auth-source
   "An OpenAI API key (string).
 


### PR DESCRIPTION
This is an amazing package. 

In many organizations the openai api can only be accessed via proxy. This is something easily supported by curl. This PR proposes an (optionally empty) path to a proxy to enable gptel in these cases.

Implemented in two commits purely for expository reasons (easily squashed into one)

The first commit minimally shows how simple the change is, the crux of that diff being:

```
@@ -54,6 +61,12 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
     ;; (push (format "--keepalive-time %s" 240) args)
     (push (format "-m%s" 60) args)
     (push "-D-" args)
+    (when (not (string-empty-p gptel-proxy-path))
+      (push "--proxy" args)
+      (push (format "%s" gptel-proxy-path) args)
+      (push "--proxy-negotiate" args)
+      (push "--proxy-user" args)
+      (push ":" args))
```

The second commit is a proposed cleanup of the overall function (from a bunch of single pushes) to leveraging `list` and `append` and also avoiding a reverse at the end. Both commits worked with and without a proxy server.

(GPT-4, together with `gptel`, actually helped with parts of the second commit)