### PR TITLE
Update gptel.el: Needs :require for auth-source-search

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -229,7 +229,8 @@ To set the temperature for a chat session interactively call
 By default, `gptel-host' is used as HOST and \"apikey\" as USER."
   (if-let ((secret (plist-get (car (auth-source-search
                                     :host (or host gptel-host)
-                                    :user (or user "apikey")))
+                                    :user (or user "apikey")
+                                    :require '(:secret)))
                               :secret)))
       (if (functionp secret)
           (encode-coding-string (funcall secret) 'utf-8)


### PR DESCRIPTION
To read from .authinfo.gpg the key parameter :require for auth-source-search is needed.