### PR TITLE
Fix read temperature from minibuffer

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -242,7 +242,8 @@ include."
   :variable 'gptel--num-messages-to-send
   :key "n"
   :prompt "Number of past messages to include for context (leave empty for all): "
-  :reader 'transient-read-number-N0)
+  :reader (lambda (prompt initial-input history)
+            (read-from-minibuffer prompt initial-input read-expression-map t history)))
 
 (transient-define-infix gptel--infix-max-tokens ()
   "Max tokens per response.
@@ -259,7 +260,8 @@ will get progressively longer!"
   :variable 'gptel-max-tokens
   :key "<"
   :prompt "Response length in tokens (leave empty: default, 80-200: short, 200-500: long): "
-  :reader 'transient-read-number-N+)
+  :reader (lambda (prompt initial-input history)
+            (read-from-minibuffer prompt initial-input read-expression-map t history)))
 
 (transient-define-infix gptel--infix-model ()
   "AI Model for Chat."
@@ -279,9 +281,9 @@ will get progressively longer!"
   :class 'transient-lisp-variable
   :variable 'gptel-temperature
   :key "t"
-  :reader (lambda (&rest _)
-            (read-from-minibuffer "Set temperature (0.0-2.0, leave empty for default): "
-                                  (number-to-string gptel-temperature))))
+  :prompt "Set temperature (0.0-2.0, leave empty for default): "
+  :reader (lambda (prompt initial-input history)
+            (read-from-minibuffer prompt initial-input read-expression-map t history)))
 
 ;; ** Infix for the refactor/rewrite system message
 

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -230,6 +230,10 @@ Customize `gptel-directives' for task-specific prompts."
 
 ;; ** Infixes for model parameters
 
+(defun gptel--transient-read-variable (prompt initial-input history)
+  "Read value from minibuffer and interpret the result as a Lisp object."
+  (read-from-minibuffer prompt initial-input read-expression-map t history))
+
 (transient-define-infix gptel--infix-num-messages-to-send ()
   "Number of recent messages to send with each exchange.
 
@@ -242,8 +246,7 @@ include."
   :variable 'gptel--num-messages-to-send
   :key "n"
   :prompt "Number of past messages to include for context (leave empty for all): "
-  :reader (lambda (prompt initial-input history)
-            (read-from-minibuffer prompt initial-input read-expression-map t history)))
+  :reader 'gptel--transient-read-variable)
 
 (transient-define-infix gptel--infix-max-tokens ()
   "Max tokens per response.
@@ -260,8 +263,7 @@ will get progressively longer!"
   :variable 'gptel-max-tokens
   :key "<"
   :prompt "Response length in tokens (leave empty: default, 80-200: short, 200-500: long): "
-  :reader (lambda (prompt initial-input history)
-            (read-from-minibuffer prompt initial-input read-expression-map t history)))
+  :reader 'gptel--transient-read-variable)
 
 (transient-define-infix gptel--infix-model ()
   "AI Model for Chat."
@@ -282,8 +284,7 @@ will get progressively longer!"
   :variable 'gptel-temperature
   :key "t"
   :prompt "Set temperature (0.0-2.0, leave empty for default): "
-  :reader (lambda (prompt initial-input history)
-            (read-from-minibuffer prompt initial-input read-expression-map t history)))
+  :reader 'gptel--transient-read-variable)
 
 ;; ** Infix for the refactor/rewrite system message
 

--- a/gptel.el
+++ b/gptel.el
@@ -261,6 +261,10 @@ By default, `gptel-host' is used as HOST and \"apikey\" as USER."
     ((pred functionp) (funcall gptel-api-key))
     (_ (error "`gptel-api-key' is not set"))))
 
+(defsubst gptel--numberize (val)
+  "Ensure VAL is a number."
+  (if (stringp val) (string-to-number val) val))
+
 (defun gptel-prompt-string ()
   (or (alist-get major-mode gptel-prompt-prefix-alist) ""))
 

--- a/gptel.el
+++ b/gptel.el
@@ -253,17 +253,13 @@ By default, `gptel-host' is used as HOST and \"apikey\" as USER."
         secret)
     (user-error "No `gptel-api-key' found in the auth source")))
 
-;; FIXME Should we utf-8 encode the api-key here? 
+;; FIXME Should we utf-8 encode the api-key here?
 (defun gptel--api-key ()
   "Get api key from `gptel-api-key'."
   (pcase gptel-api-key
     ((pred stringp) gptel-api-key)
     ((pred functionp) (funcall gptel-api-key))
     (_ (error "`gptel-api-key' is not set"))))
-
-(defsubst gptel--numberize (val)
-  "Ensure VAL is a number."
-  (if (stringp val) (string-to-number val) val))
 
 (defun gptel-prompt-string ()
   (or (alist-get major-mode gptel-prompt-prefix-alist) ""))
@@ -402,7 +398,7 @@ Model parameters can be let-bound around calls to this function."
             (set-marker (make-marker) position buffer))))
          (full-prompt
          (cond
-          ((null prompt) 
+          ((null prompt)
            (let ((gptel--system-message system))
              (gptel--create-prompt start-marker)))
           ((stringp prompt)
@@ -506,8 +502,7 @@ there."
                  (goto-char (point-max)))
         (goto-char (or prompt-end (point-max))))
       (let ((max-entries (and gptel--num-messages-to-send
-                              (* 2 (gptel--numberize
-                                    gptel--num-messages-to-send))))
+                              (* 2 gptel--num-messages-to-send)))
             (prop) (prompts))
         (while (and
                 (or (not max-entries) (>= max-entries 0))
@@ -535,9 +530,9 @@ there."
            :messages [,@prompts]
            :stream ,(or (and gptel-stream gptel-use-curl) :json-false))))
     (when gptel-temperature
-      (plist-put prompts-plist :temperature (gptel--numberize gptel-temperature)))
+      (plist-put prompts-plist :temperature gptel-temperature))
     (when gptel-max-tokens
-      (plist-put prompts-plist :max_tokens (gptel--numberize gptel-max-tokens)))
+      (plist-put prompts-plist :max_tokens gptel-max-tokens))
     prompts-plist))
 
 ;; TODO: Use `run-hook-wrapped' with an accumulator instead to handle


### PR DESCRIPTION
The returned result now is a string instead of a number, and the code is from `set-variable`.