### PR TITLE
Allow setting query protocol

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -41,7 +41,7 @@
   "Produce list of arguments for calling Curl.
 
 PROMPTS is the data to send, TOKEN is a unique identifier."
-  (let* ((url (format "https://%s/v1/chat/completions" gptel-host))
+  (let* ((url (format "%s://%s/v1/chat/completions" gptel-protocol gptel-host))
          (data (encode-coding-string
                 (json-encode (gptel--request-data prompts))
                 'utf-8))

--- a/gptel.el
+++ b/gptel.el
@@ -85,6 +85,11 @@
   :group 'gptel
   :type 'string)
 
+(defcustom gptel-protocol "https"
+  "Protocol to query the API with."
+  :group 'gptel
+  :type 'string)
+
 (defcustom gptel-proxy ""
   "Path to a proxy to use for gptel interactions.
 Passed to curl via --proxy arg, for example \"proxy.yourorg.com:80\"
@@ -766,7 +771,8 @@ the response is inserted into the current buffer after point."
          (encode-coding-string
           (json-encode (gptel--request-data (plist-get info :prompt)))
           'utf-8)))
-    (url-retrieve (format "https://%s/v1/chat/completions" gptel-host)
+    (url-retrieve (format "%s://%s/v1/chat/completions"
+                          gptel-protocol gptel-host)
                   (lambda (_)
                     (pcase-let ((`(,response ,http-msg ,error)
                                  (gptel--url-parse-response (current-buffer))))


### PR DESCRIPTION
`https` was previously hardcoded; this allows other protocols to be used (useful for hosting locally) while keeping the default.