### PR TITLE
Add custom gptel-update-destination

### DIFF
--- a/README.org
+++ b/README.org
@@ -344,7 +344,7 @@ Other Emacs clients for LLMs prescribe the format of the interaction (a comint s
 | =gptel-default-mode=          | Major mode for dedicated chat buffers. |
 | =gptel-prompt-prefix-alist=   | Text inserted before queries.          |
 | =gptel-response-prefix-alist= | Text inserted before responses.        |
-| =gptel-update-destination=  | Display status messages in headerline (default) or minibuffer       |
+| =gptel-use-header-line= | Display status messages in header-line (default) or minibuffer      |
 |-----------------------------+----------------------------------------|
 
 ** COMMENT Will you add feature X?

--- a/README.org
+++ b/README.org
@@ -344,6 +344,7 @@ Other Emacs clients for LLMs prescribe the format of the interaction (a comint s
 | =gptel-default-mode=          | Major mode for dedicated chat buffers. |
 | =gptel-prompt-prefix-alist=   | Text inserted before queries.          |
 | =gptel-response-prefix-alist= | Text inserted before responses.        |
+| =gptel-update-destination=  | Display status messages in headerline (default) or minibuffer       |
 |-----------------------------+----------------------------------------|
 
 ** COMMENT Will you add feature X?

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -155,7 +155,7 @@ the response is inserted into the current buffer after point."
         (delete-process proc)
         (kill-buffer (process-buffer proc))
         (with-current-buffer buf
-          (when gptel-mode (gptel--update-header-line  " Ready" 'success)))
+          (when gptel-mode (gptel--update-status  " Ready" 'success)))
         (message "Stopped gptel request in buffer %S" (buffer-name buf)))
     (message "No gptel request associated with buffer %S" (buffer-name buf))))
 
@@ -185,7 +185,7 @@ PROCESS and _STATUS are process parameters."
               (when gptel-mode (save-excursion (goto-char tracking-marker)
                                                (insert "\n\n" (gptel-prompt-prefix-string)))))
             (with-current-buffer gptel-buffer
-              (when gptel-mode (gptel--update-header-line  " Ready" 'success))))
+              (when gptel-mode (gptel--update-status  " Ready" 'success))))
         ;; Or Capture error message
         (with-current-buffer proc-buf
           (goto-char (point-max))
@@ -210,7 +210,7 @@ PROCESS and _STATUS are process parameters."
              (t (message "ChatGPT error (%s): Could not parse HTTP response." http-msg)))))
         (with-current-buffer gptel-buffer
           (when gptel-mode
-            (gptel--update-header-line
+            (gptel--update-status
              (format " Response Error: %s" http-msg) 'error))))
       (with-current-buffer gptel-buffer
         (run-hooks 'gptel-post-response-hook)))
@@ -229,7 +229,7 @@ See `gptel--url-get-response' for details."
         (with-current-buffer (marker-buffer start-marker)
           (save-excursion
             (unless tracking-marker
-              (gptel--update-header-line " Typing..." 'success)
+              (gptel--update-status " Typing..." 'success)
               (goto-char start-marker)
               (unless (or (bobp) (plist-get info :in-place))
                 (insert "\n\n")

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -418,7 +418,7 @@ will get progressively longer!"
                           (gptel--at-word-end (point)))))))
       (with-current-buffer buffer
         (setq gptel-backend backend)
-        (gptel--update-header-line " Waiting..." 'warning)
+        (gptel--update-status " Waiting..." 'warning)
         (setq position (point)))
       (setq output-to-other-buffer-p t))
      ((setq gptel-buffer-name
@@ -449,7 +449,7 @@ will get progressively longer!"
             (insert reduced-prompt))
           (setq position (point))
           (when gptel-mode
-            (gptel--update-header-line " Waiting..." 'warning))))))
+            (gptel--update-status " Waiting..." 'warning))))))
 
     (when in-place
       (setq prompt (gptel--create-prompt (point)))


### PR DESCRIPTION
This PR proposes a customisable option `gptel-update-destination` to enable status messages to appear strictly in the minibuffer and never appear in the header line. 