### PR TITLE
Increased curl timeout

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -55,7 +55,7 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
      (list "--location" "--silent" "--compressed" "--disable"
            (format "-X%s" "POST")
            (format "-w(%s . %%{size_header})" token)
-           (format "-m%s" 60)
+           (format "-m%s" 300)
            "-D-"
            (format "-d%s" data))
      (when (not (string-empty-p gptel-proxy))


### PR DESCRIPTION
Often local LLMs will offload a query to CPU if there is not enough VRAM or in
the case of an unsupported GPU. When a query is offloaded to the CPU responses
can be significantly slower. If curl times out early the user will not get the
response from the LLM back in Emacs.

This change increases the timeout for curl from 60s to 300s to make gptel usable
in slower environments.

Closes #125