### PR TITLE
Fix for "argument list too long" error with large payloads in Curl

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -62,7 +62,7 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
     (append
      gptel-curl--common-args
      (list (format "-w(%s . %%{size_header})" token))
-     (if (length> data gptel-curl-args-file-threshold)
+     (if (length> data gptel-curl-file-size-threshold)
          (list "--data-binary"
                (format "@%s" (make-temp-file "gptel-curl-data" nil ".json" data)))
        (list (format "-d%s" data)))

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -61,8 +61,11 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
                       backend-header)))))
     (append
      gptel-curl--common-args
-     (list (format "-w(%s . %%{size_header})" token)
-           (format "-d%s" data))
+     (list (format "-w(%s . %%{size_header})" token))
+     (if (length> data gptel-curl-args-file-threshold)
+         (list "--data-binary"
+               (format "@%s" (make-temp-file "gptel-curl-data" nil ".json" data)))
+       (list (format "-d%s" data)))
      (when (not (string-empty-p gptel-proxy))
        (list "--proxy" gptel-proxy
              "--proxy-negotiate"

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -47,8 +47,7 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
                 'utf-8))
          (headers
           (append '(("Content-Type" . "application/json"))
-                  (when-let ((backend-header
-                              (gptel-backend-header gptel-backend)))
+                  (when-let ((backend-header (gptel-backend-header gptel-backend)))
                     (if (functionp backend-header)
                         (funcall backend-header)
                       backend-header))))
@@ -67,7 +66,6 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
      (cl-loop for (key . val) in headers
               collect (format "-H%s: %s" key val))
      (list url))))
-
 
 ;;TODO: The :transformer argument here is an alternate implementation of
 ;;`gptel-response-filter-functions'. The two need to be unified.

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -62,10 +62,17 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
     (append
      gptel-curl--common-args
      (list (format "-w(%s . %%{size_header})" token))
-     (if (length> data gptel-curl-file-size-threshold)
+     (if (length< data gptel-curl-file-size-threshold)
+         (list (format "-d%s" data))
+       (letrec
+           ((temp-filename (make-temp-file "gptel-curl-data" nil ".json" data))
+            (cleanup-fn (lambda ()
+                          (when (file-exists-p temp-filename)
+                            (delete-file temp-filename)
+                            (remove-hook 'gptel-post-response-hook cleanup-fn)))))
+         (add-hook 'gptel-post-response-hook cleanup-fn)
          (list "--data-binary"
-               (format "@%s" (make-temp-file "gptel-curl-data" nil ".json" data)))
-       (list (format "-d%s" data)))
+               (format "@%s" temp-filename))))
      (when (not (string-empty-p gptel-proxy))
        (list "--proxy" gptel-proxy
              "--proxy-negotiate"

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -47,14 +47,15 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
                 'utf-8))
          (headers
           `(("Content-Type" . "application/json")
-            ("Authorization" . ,(concat "Bearer " (gptel--api-key))))))
+            ("Authorization" . ,(concat "Bearer " (gptel--api-key)))))
+         (data-file (make-temp-file "gptel-curl-data" nil ".json" data)))
     (append
      (list "--location" "--silent" "--compressed" "--disable"
            (format "-X%s" "POST")
            (format "-w(%s . %%{size_header})" token)
            (format "-m%s" 60)
            "-D-"
-           (format "-d%s" data))
+           "--data-binary" (format "@%s" data-file))
      (when (not (string-empty-p gptel-proxy))
        (list "--proxy" gptel-proxy
              "--proxy-negotiate"

--- a/gptel.el
+++ b/gptel.el
@@ -163,6 +163,25 @@ all at once. This wait is asynchronous.
   :group 'gptel
   :type 'boolean)
 
+(defcustom gptel-curl-args-file-threshold 130000
+  "Size threshold for using file input with Curl.
+
+Specifies the size threshold for when to use a temporary file to pass data to
+Curl in GPTel queries. If the size of the data to be sent exceeds this
+threshold, the data is written to a temporary file and passed to Curl using the
+`--data-binary' option with a file reference. Otherwise, the data is passed
+directly as a command-line argument.
+
+The value is an integer representing the number of bytes.
+
+Adjusting this value may be necessary depending on the environment
+and the typical size of the data being sent in GPTel queries.
+A larger value may improve performance by avoiding the overhead of creating
+temporary files for small data payloads, while a smaller value may be needed
+if the command-line argument size is limited by the operating system."
+  :group 'gptel
+  :type 'integer)
+
 (defcustom gptel-response-filter-functions
   '(gptel--convert-org)
   "Abnormal hook for transforming the response from ChatGPT.

--- a/gptel.el
+++ b/gptel.el
@@ -163,7 +163,7 @@ all at once. This wait is asynchronous.
   :group 'gptel
   :type 'boolean)
 
-(defcustom gptel-curl-args-file-threshold 130000
+(defcustom gptel-curl-file-size-threshold 130000
   "Size threshold for using file input with Curl.
 
 Specifies the size threshold for when to use a temporary file to pass data to


### PR DESCRIPTION
Firstly, I'd like to express my gratitude for the excellent `gptel` package.

Recently, with the release of newer models boasting a 128k context (e.g., `gpt-4-1106-preview`), I attempted to utilize these capabilities with a sizable amount of data. However, I encountered a stumbling block when `gptel-stream-response` failed due to a Curl error stating that the "argument list [was] too long."

Upon investigation, I found that the issue arose from attempting to pass a large payload directly to Curl via command-line arguments. To overcome this limitation, I have implemented a solution that writes the JSON-encoded data to a temporary file and instructs Curl to transmit this data using the `--data-binary` flag, which points to the said file. This eliminates the problem of exceeding the maximum argument length imposed by most operating systems on command-line inputs.

**Changes Made:**
To resolve this, the method of sending data to Curl has been modified. Instead of including the data directly in the command-line arguments using the `-d` option, the data is now written to a temporary JSON file. Curl is then instructed to read from this file using the `--data-binary` option.

**Technical Details:**
- A temporary file is created using `make-temp-file` to hold the encoded JSON data.
- The `--data-binary` Curl option is used to send the data by reading from the temporary file, thus avoiding the system's command-line length limitations.
- The Curl command in the `gptel-curl--get-args` function is adjusted accordingly.

This change ensures that users can work with larger data payloads without encountering Curl's argument size constraints while sending requests to the larger and more advanced GPT-4 models.

Thank you once again for your efforts in maintaining this package.