### PR TITLE
Capture text from gptel-system buffer before swapping buffer context.

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -543,9 +543,9 @@ This uses the prompts in the variable
       (local-set-key (kbd "C-c C-c")
                      (lambda ()
                        (interactive)
-                       (with-current-buffer orig-buf
-                         (setq gptel--system-message
-                               (buffer-substring msg-start (point-max))))
+                       (let ((sys-message (buffer-substring msg-start (point-max))))
+                         (with-current-buffer orig-buf
+                           (setq gptel--system-message sys-message)))
                        (quit-window)
                        (display-buffer
                         orig-buf


### PR DESCRIPTION
Fix for https://github.com/karthink/gptel/issues/138

I'm not well versed in elisp so maybe there is a more idiomatic way to fix this, but figured I'd give it a shot. 

As best I understand it, in 3c01477c37f494e4421970dcf2ddb69c25958aa7 the code changed to use `with-current-buffer orig-buf` but then within that context the `buffer-substring` function acts on the original buffer where the command was issued from, not on the `*gptel-system*` buffer where the user has entered text, so it sets the prompt to the wrong thing. 