### PR TITLE
Add multiline prefixes & AI response prefixes

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -168,13 +168,7 @@ PROCESS and _STATUS are process parameters."
             (with-current-buffer (marker-buffer start-marker)
               (pulse-momentary-highlight-region (+ start-marker 2) tracking-marker)
               (when gptel-mode (save-excursion (goto-char tracking-marker)
-                                               (insert "\n\n" (gptel-prompt-prefix-string))
-                                               ;; Go to point right after the two newlines that
-                                               ;; were inserted right after the user prompt.
-                                               (goto-char (+ 2 start-marker))
-                                               ;; Put prefix on AI response after the AI
-                                               ;; response has been fully received.
-                                               (insert (gptel-response-prefix-string)))))
+                                               (insert "\n\n" (gptel-prompt-prefix-string)))))
             (with-current-buffer gptel-buffer
               (when gptel-mode (gptel--update-header-line  " Ready" 'success))))
         ;; Or Capture error message
@@ -223,7 +217,11 @@ See `gptel--url-get-response' for details."
               (gptel--update-header-line " Typing..." 'success)
               (goto-char start-marker)
               (unless (or (bobp) (plist-get info :in-place))
-                (insert "\n\n"))
+                (insert "\n\n")
+                (when gptel-mode
+                  ;; Put prefix on AI response after the AI
+                  ;; response has been fully received.
+                  (insert (gptel-response-prefix-string))))
               (setq tracking-marker (set-marker (make-marker) (point)))
               (set-marker-insertion-type tracking-marker t)
               (plist-put info :tracking-marker tracking-marker))

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -168,7 +168,13 @@ PROCESS and _STATUS are process parameters."
             (with-current-buffer (marker-buffer start-marker)
               (pulse-momentary-highlight-region (+ start-marker 2) tracking-marker)
               (when gptel-mode (save-excursion (goto-char tracking-marker)
-                                               (insert "\n\n" (gptel-prompt-string)))))
+                                               (insert "\n\n" (gptel-prompt-prefix-string))
+                                               ;; Go to point right after the two newlines that
+                                               ;; were inserted right after the user prompt.
+                                               (goto-char (+ 2 start-marker))
+                                               ;; Put prefix on AI response after the AI
+                                               ;; response has been fully received.
+                                               (insert (gptel-response-prefix-string)))))
             (with-current-buffer gptel-buffer
               (when gptel-mode (gptel--update-header-line  " Ready" 'success))))
         ;; Or Capture error message

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -219,8 +219,7 @@ See `gptel--url-get-response' for details."
               (unless (or (bobp) (plist-get info :in-place))
                 (insert "\n\n")
                 (when gptel-mode
-                  ;; Put prefix on AI response after the AI
-                  ;; response has been fully received.
+                  ;; Put prefix before AI response.
                   (insert (gptel-response-prefix-string))))
               (setq tracking-marker (set-marker (make-marker) (point)))
               (set-marker-insertion-type tracking-marker t)

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -89,9 +89,11 @@ Ollama models.")
                      :system gptel--system-message
                      :prompt
                      (if (prop-match-p prop)
-                         (string-trim (buffer-substring-no-properties (prop-match-beginning prop)
-                                                                      (prop-match-end prop))
-                                      "[*# \t\n\r]+")
+                         (string-trim
+                          (buffer-substring-no-properties (prop-match-beginning prop)
+                                                          (prop-match-end prop))
+                          (format "[\t\r\n ]*%s[\t\r\n ]*" (regexp-quote (gptel-prompt-prefix-string)))
+                          (format "[\t\r\n ]*%s[\t\r\n ]*" (regexp-quote (gptel-response-prefix-string))))
                        ""))))))
 
 ;;;###autoload

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -100,7 +100,8 @@
                   (string-trim
                    (buffer-substring-no-properties (prop-match-beginning prop)
                                                    (prop-match-end prop))
-                   "[*# \t\n\r]+"))
+                   (format "[\t\r\n ]*%s[\t\r\n ]*" (regexp-quote (gptel-prompt-prefix-string)))
+                   (format "[\t\r\n ]*%s[\t\r\n ]*" (regexp-quote (gptel-response-prefix-string)))))
             prompts)
       (and max-entries (cl-decf max-entries)))
     (cons (list :role "system"

--- a/gptel.el
+++ b/gptel.el
@@ -956,7 +956,8 @@ buffer created or switched to."
     (when (called-interactively-p 'gptel)
       (pop-to-buffer (current-buffer))
       (message "Send your query with %s!"
-               (substitute-command-keys "\\[gptel-send]")))
+               (substitute-command-keys "\\[gptel-send]"))
+      (goto-char (point-max)))
     (current-buffer)))
 
 (defun gptel--convert-markdown->org (str)

--- a/gptel.el
+++ b/gptel.el
@@ -798,8 +798,8 @@ there."
        (t (goto-char (or prompt-end (point-max)))))
       (let ((max-entries (and gptel--num-messages-to-send
                               (* 2 gptel--num-messages-to-send))))
-        (let ((prompt (gptel--parse-buffer gptel-backend max-entries)))
-             (print prompt))))))
+        (gptel--parse-buffer gptel-backend max-entries)))))
+
 
 (cl-defgeneric gptel--parse-buffer (backend max-entries)
   "Parse the current buffer backwards from point and return a list

--- a/gptel.el
+++ b/gptel.el
@@ -800,7 +800,6 @@ there."
                               (* 2 gptel--num-messages-to-send))))
         (gptel--parse-buffer gptel-backend max-entries)))))
 
-
 (cl-defgeneric gptel--parse-buffer (backend max-entries)
   "Parse the current buffer backwards from point and return a list
 of prompts.
@@ -932,7 +931,6 @@ See `gptel-curl--get-response' for its contents.")
         (list nil (concat "(" http-msg ") Could not parse HTTP response.")
               "Could not parse HTTP response.")))))
 
-(defvar gptel--prefix-chars-to-skip "\t\r\n")
 ;;;###autoload
 (defun gptel (name &optional _ initial)
   "Switch to or start ChatGPT session with NAME.
@@ -968,9 +966,9 @@ buffer created or switched to."
       (visual-line-mode 1))
      (t (funcall gptel-default-mode)))
     (unless gptel-mode (gptel-mode 1))
+    (skip-chars-backward "\t\r\n")
     (if (bobp) (insert (or initial (gptel-prompt-prefix-string))))
     (goto-char (point-max))
-    (skip-chars-backward gptel--prefix-chars-to-skip)
     (when (called-interactively-p 'gptel)
       (pop-to-buffer (current-buffer))
       (message "Send your query with %s!"

--- a/gptel.el
+++ b/gptel.el
@@ -206,9 +206,9 @@ defaults to `text-mode'."
 
 ;; TODO: Handle `prog-mode' using the `comment-start' variable
 (defcustom gptel-prompt-prefix-alist
-  '((markdown-mode . "## ")
-    (org-mode . "** ")
-    (text-mode . "## "))
+  '((markdown-mode . "### ")
+    (org-mode . "*** ")
+    (text-mode . "### "))
   "String inserted after the response from ChatGPT.
 
 This is an alist mapping major modes to the prefix strings.  This

--- a/gptel.el
+++ b/gptel.el
@@ -966,9 +966,9 @@ buffer created or switched to."
       (visual-line-mode 1))
      (t (funcall gptel-default-mode)))
     (unless gptel-mode (gptel-mode 1))
+    (goto-char (point-max))
     (skip-chars-backward "\t\r\n")
     (if (bobp) (insert (or initial (gptel-prompt-prefix-string))))
-    (goto-char (point-max))
     (when (called-interactively-p 'gptel)
       (pop-to-buffer (current-buffer))
       (message "Send your query with %s!"


### PR DESCRIPTION
This makes it so that prefixes with newlines are respected s.t. the point is moved to the end of the prefix:

![image](https://github.com/karthink/gptel/assets/41439659/6d1c187e-f265-41c4-9dcb-4361b3dda746)

Before, the point would be at the end of the first line. This saves two key presses.