### PR TITLE
gptel: Allow setting custom curl path

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -106,9 +106,9 @@ the response is inserted into the current buffer after point."
          (args (gptel-curl--get-args (plist-get info :prompt) token))
          (stream (and gptel-stream (gptel-backend-stream gptel-backend)))
          (process (apply #'start-process "gptel-curl"
-                         (generate-new-buffer "*gptel-curl*") "curl" args)))
+                         (generate-new-buffer "*gptel-curl*") gptel-curl-path args)))
     (when (eq gptel-log-level 'debug)
-      (gptel--log (json-encode (cons "curl" args))
+      (gptel--log (json-encode (cons gptel-curl-path args))
                   "request Curl command"))
     (with-current-buffer (process-buffer process)
       (set-process-query-on-exit-flag process nil)

--- a/gptel.el
+++ b/gptel.el
@@ -184,7 +184,12 @@ all at once.  This wait is asynchronous.
   :type 'boolean)
 (make-obsolete-variable 'gptel-playback 'gptel-stream "0.3.0")
 
-(defcustom gptel-use-curl (and (executable-find "curl") t)
+(defcustom gptel-curl-path "curl"
+  "The path to the curl executable."
+  :group 'gptel
+  :type 'string)
+
+(defcustom gptel-use-curl (and (executable-find gptel-curl-path) t)
   "Whether gptel should prefer Curl when available."
   :group 'gptel
   :type 'boolean)


### PR DESCRIPTION
This commit allows the user to set a custom path to the curl executable.

Windows has some strange notions of what "curl" is, and this can't always be changed easily. With this variable, a user can let gptel use the curl executable of their choosing -- allowing full response streaming.

The default is still set to the same value it was: `"curl"`.