### PR TITLE
Update available OpenAI GPT models to match API

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -318,11 +318,11 @@ will get progressively longer!"
   :class 'transient-lisp-variable
   :variable 'gptel-model
   :key "-m"
-  :choices '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-32k")
+  :choices '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-1106-preview")
   :reader (lambda (prompt &rest _)
             (completing-read
              prompt
-             '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-32k"))))
+             '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-1106-preview"))))
 
 (transient-define-infix gptel--infix-temperature ()
   "Temperature of request."

--- a/gptel.el
+++ b/gptel.el
@@ -300,7 +300,7 @@ The current options for ChatGPT are
 - \"gpt-3.5-turbo\"
 - \"gpt-3.5-turbo-16k\"
 - \"gpt-4\" (experimental)
-- \"gpt-4-32k\" (experimental)
+- \"gpt-4-1106-preview\" (experimental)
  
 To set the model for a chat session interactively call
 `gptel-send' with a prefix argument."
@@ -310,8 +310,8 @@ To set the model for a chat session interactively call
   :type '(choice
           (const :tag "GPT 3.5 turbo" "gpt-3.5-turbo")
           (const :tag "GPT 3.5 turbo 16k" "gpt-3.5-turbo-16k")
-          (const :tag "GPT 4 (experimental)" "gpt-4")
-          (const :tag "GPT 4 32k (experimental)" "gpt-4-32k")))
+          (const :tag "GPT 4" "gpt-4")
+          (const :tag "GPT 4 turbo (preview)" "gpt-4-1106-preview")))
 
 (defcustom gptel-temperature 1.0
   "\"Temperature\" of ChatGPT response.
@@ -341,7 +341,7 @@ with differing settings.")
    :header (lambda () `(("Authorization" . ,(concat "Bearer " (gptel--get-api-key)))))
    :key 'gptel-api-key
    :stream t
-   :models '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-32k")))
+   :models '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-1106-preview")))
 
 (defvar-local gptel-backend gptel--openai)
 


### PR DESCRIPTION
Since a month, OpenAI offers access to the faster and cheaper GPT4 turbo model. This PR replaces the non-existent GPT-4-32k model with that new existent model