### PR TITLE
update the instruction for Azure

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,8 +133,9 @@ Register a backend with
  "Azure-1"                              ;Name, whatever you'd like
  :protocol "https"                      ;optional -- https is the default
  :host "YOUR_RESOURCE_NAME.openai.azure.com"
- :endpoint "/openai/deployments/YOUR_DEPLOYMENT_NAME/completions?api-version=2023-05-15" ;or equivalent
+ :endpoint "/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2023-05-15" ;or equivalent
  :stream t                              ;Enable streaming responses
+ :key #'gptel-api-key
  :models '("gpt-3.5-turbo" "gpt-4"))
 #+end_src
 Refer to the documentation of =gptel-make-azure= to set more parameters.


### PR DESCRIPTION
1. According to Azure OpenAI [documents](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=command-line%2Cpython&pivots=rest-api), the chat API endpoint should be "/openai/deployments/gpt-4/chat/completions?api-version=2023-05-15" and the one show in README is the [completion API](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line%2Cpython&pivots=rest-api) without "chat".
2. Azure OpenAI also requires an API key.

This PR is related to https://github.com/karthink/gptel/issues/143.