### PR TITLE
Add support for mutual TLS

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -78,6 +78,10 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
          (add-hook 'gptel-post-response-functions cleanup-fn)
          (list "--data-binary"
                (format "@%s" temp-filename))))
+     (when-let (certificate (gptel-backend-client-certificate gptel-backend))
+       (list "--cert" certificate))
+     (when-let (key (gptel-backend-client-private-key gptel-backend))
+       (list "--key" key))
      (when (not (string-empty-p gptel-proxy))
        (list "--proxy" gptel-proxy
              "--proxy-negotiate"
@@ -265,10 +269,10 @@ See `gptel--url-get-response' for details."
               (setq tracking-marker (set-marker (make-marker) (point)))
               (set-marker-insertion-type tracking-marker t)
               (plist-put info :tracking-marker tracking-marker))
-            
+
             (when transformer
               (setq response (funcall transformer response)))
-            
+
             (add-text-properties
              0 (length response) '(gptel response rear-nonsticky t)
              response)
@@ -285,7 +289,7 @@ See `gptel--url-get-response' for details."
         (goto-char (process-mark process))
         (insert output)
         (set-marker (process-mark process) (point)))
-      
+
       ;; Find HTTP status
       (unless (plist-get proc-info :http-status)
         (save-excursion
@@ -318,7 +322,7 @@ See `gptel--url-get-response' for details."
                    gptel-pre-response-hook)
           (with-current-buffer (marker-buffer (plist-get proc-info :position))
             (run-hooks 'gptel-pre-response-hook))))
-      
+
       (when-let ((http-msg (plist-get proc-info :status))
                  (http-status (plist-get proc-info :http-status)))
         ;; Find data chunk(s) and run callback

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -49,7 +49,8 @@
     (gptel-backend (:constructor gptel--make-backend)
                    (:copier gptel--copy-backend))
   name host header protocol stream
-  endpoint key models url)
+  endpoint key models url
+  client-certificate client-private-key)
 
 ;;; OpenAI (ChatGPT)
 (cl-defstruct (gptel-openai (:constructor gptel--make-openai)


### PR DESCRIPTION
Hi @karthink,

first, thanks for GPTel and the great video you made about it. I enjoyed it!

I would like to use GPTel with an OpenAI gateway at work that requires mutual TLS. 

This change adds 2 new slots to the `gptel-backend` struct to support mutual TLS:

- The optional `client-certificate` slot is used to set the filename of the TLS client certificate.

- The optional `client-private-key` slot is used to set the filename of the private key of the TLS client.

The client certificate and private key are then used in the curl backend via the `--cert` and `--key` options when making HTTP requests.

There's one caveat. Ideally this would also be added for the `url-retrieve` backend. I would have liked to test this with the gateway I'm using, but for some reason GNUTLS has issues with the client certificate and key I have at hand. It might be that it works out of the box by adding something like this to your `~/.authinfo.gpg` file and set `network-stream-use-client-certificates`:

```
machine gateway.exmple.com port 443 key /path/to/my-key.pem cert /path/to/my-cert.pem
```

But I couldn't get this working. The changes to the curl backend would allow me to use a LLM at work.
 
Would you like to add this to GPTel?

Thanks, Roman.