### PR TITLE
Add curl-args slot to gptel-backend

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -66,6 +66,7 @@ PROMPTS is the data to send, TOKEN is a unique identifier."
       (gptel--log data "request body"))
     (append
      gptel-curl--common-args
+     (gptel-backend-curl-args gptel-backend)
      (list (format "-w(%s . %%{size_header})" token))
      (if (length< data gptel-curl-file-size-threshold)
          (list (format "-d%s" data))

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -111,7 +111,7 @@
 
 ;;;###autoload
 (cl-defun gptel-make-gemini
-    (name &key header key (stream nil)
+    (name &key curl-args header key (stream nil)
           (host "generativelanguage.googleapis.com")
           (protocol "https")
           (models '("gemini-pro"))
@@ -120,6 +120,8 @@
   "Register a Gemini backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST (optional) is the API host, defaults to
 \"generativelanguage.googleapis.com\".
@@ -145,6 +147,7 @@ KEY (optional) is a variable whose value is the API key, or
 function that returns the key."
   (declare (indent 1))
   (let ((backend (gptel--make-gemini
+                  :curl-args curl-args
                   :name name
                   :host host
                   :header header

--- a/gptel-kagi.el
+++ b/gptel-kagi.el
@@ -120,7 +120,7 @@
 
 ;;;###autoload
 (cl-defun gptel-make-kagi
-    (name &key stream key
+    (name &key curl-args stream key
           (host "kagi.com")
           (header (lambda () `(("Authorization" . ,(concat "Bot " (gptel--get-api-key))))))
           (models '("fastgpt"
@@ -131,6 +131,8 @@
   "Register a Kagi FastGPT backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST is the Kagi host (with port), defaults to \"kagi.com\".
 
@@ -159,6 +161,7 @@ Example:
   (declare (indent 1))
   stream                                ;Silence byte-compiler
   (let ((backend (gptel--make-kagi
+                  :curl-args curl-args
                   :name name
                   :host host
                   :header header

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -101,13 +101,15 @@ Ollama models.")
 
 ;;;###autoload
 (cl-defun gptel-make-ollama
-    (name &key header key models stream
+    (name &key curl-args header key models stream
           (host "localhost:11434")
           (protocol "http")
           (endpoint "/api/generate"))
   "Register an Ollama backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST is where Ollama runs (with port), defaults to localhost:11434
 
@@ -140,6 +142,7 @@ Example:
   :stream t)"
   (declare (indent 1))
   (let ((backend (gptel--make-ollama
+                  :curl-args curl-args
                   :name name
                   :host host
                   :header header

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -49,7 +49,7 @@
     (gptel-backend (:constructor gptel--make-backend)
                    (:copier gptel--copy-backend))
   name host header protocol stream
-  endpoint key models url)
+  endpoint key models url curl-args)
 
 ;;; OpenAI (ChatGPT)
 (cl-defstruct (gptel-openai (:constructor gptel--make-openai)
@@ -115,7 +115,7 @@
 
 ;;;###autoload
 (cl-defun gptel-make-openai
-    (name &key models stream key
+    (name &key curl-args models stream key
           (header
            (lambda () (when-let (key (gptel--get-api-key))
                    `(("Authorization" . ,(concat "Bearer " key))))))
@@ -125,6 +125,8 @@
   "Register an OpenAI API-compatible backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST (optional) is the API host, typically \"api.openai.com\".
 
@@ -147,6 +149,7 @@ KEY (optional) is a variable whose value is the API key, or
 function that returns the key."
   (declare (indent 1))
   (let ((backend (gptel--make-openai
+                  :curl-args curl-args
                   :name name
                   :host host
                   :header header
@@ -166,7 +169,7 @@ function that returns the key."
 ;;; Azure
 ;;;###autoload
 (cl-defun gptel-make-azure
-    (name &key host
+    (name &key curl-args host
           (protocol "https")
           (header (lambda () `(("api-key" . ,(gptel--get-api-key)))))
           (key 'gptel-api-key)
@@ -174,6 +177,8 @@ function that returns the key."
   "Register an Azure backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST is the API host.
 
@@ -207,6 +212,7 @@ Example:
  :models \\='(\"gpt-3.5-turbo\" \"gpt-4\"))"
   (declare (indent 1))
   (let ((backend (gptel--make-openai
+                  :curl-args curl-args
                   :name name
                   :host host
                   :header header
@@ -229,6 +235,8 @@ Example:
   "Register a GPT4All backend for gptel with NAME.
 
 Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
 
 HOST is where GPT4All runs (with port), typically localhost:8491
 


### PR DESCRIPTION
This slot is used to append backend specific options to the curl arguments used to make HTTP requests. The backend specific arguments are appended after `gptel-curl--common-args`.

My use case for this feature is to set the `--cert` and `--key` options in a custom backend that uses mutal TLS to communicate with an OpenAI proxy/gateway.