### PR TITLE
Description in system directives; a summary for complex prompts

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -353,9 +353,9 @@ transient menu interface provided by `gptel-menu'."
 
 ;; Model and interaction parameters
 (defcustom gptel-directives
-  '((default . "You are a large language model living in Emacs and a helpful assistant. Respond concisely.")
-    (programming . "You are a large language model and a careful programmer. Provide code and only code as output without any additional text, prompt or note.")
-    (writing . "You are a large language model and a writing assistant. Respond concisely.")
+  `((default "Default " "You are a large language model living in Emacs and a helpful assistant. Respond concisely.") ;; there must be a default prompt
+    (programming "Programming help" "You are a large language model and a careful programmer. Provide code and only code as output without any additional text, prompt or note.")
+    (writing "Writing help" "You are a large language model and a writing assistant. Respond concisely.")
     (chat . "You are a large language model and a conversation partner. Respond concisely."))
   "System prompts (directives) for the LLM.
 
@@ -367,9 +367,11 @@ the string that is sent.  To set the directive for a chat session
 interactively call `gptel-send' with a prefix argument."
   :group 'gptel
   :safe #'always
-  :type '(alist :key-type symbol :value-type string))
+  :type '(alist :key-type (symbol :tag "directive-key")
+                :value-type (list (string :tag "Description")
+                                  (string :tag "Directive/System prompt"))))
 
-(defvar gptel--system-message (alist-get 'default gptel-directives)
+(defvar gptel--system-message (cadr (alist-get 'default gptel-directives))
   "The system message used by gptel.")
 (put 'gptel--system-message 'safe-local-variable #'always)
 


### PR DESCRIPTION
I  add descriptions in my growing list of long complex gptel directives.

I find it helpful to use as a memory jog or summary of what long complex prompts are supposed to accomplish.

It has proven useful in a custom non-transient-mode function that uses annotations and looks like this:
![completing-read-gptel-directives-with-description](https://github.com/karthink/gptel/assets/162285/db57528e-5005-416f-95e7-9aadf2d5ef10)

Note that any prompt with no description set shows as "NO DESCRIPTION".

This change includes the definition needed for the customization framework, and still works with the existing transient selection framework.  