### PR TITLE
gptel asks user to select a buffer if many are open

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2023  Karthik Chikmagalur
 
 ;; Author: Karthik Chikmagalur <karthik.chikmagalur@gmail.com>
-;; Version: 999.git
+;; Version: 0.8.6
 ;; Package-Requires: ((emacs "27.1") (transient "0.4.0") (compat "29.1.4.1"))
 ;; Keywords: convenience
 ;; URL: https://github.com/karthink/gptel

--- a/gptel.el
+++ b/gptel.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2023  Karthik Chikmagalur
 
 ;; Author: Karthik Chikmagalur <karthik.chikmagalur@gmail.com>
-;; Version: 0.8.6
+;; Version: 999.git
 ;; Package-Requires: ((emacs "27.1") (transient "0.4.0") (compat "29.1.4.1"))
 ;; Keywords: convenience
 ;; URL: https://github.com/karthink/gptel
@@ -1215,20 +1215,16 @@ INTERACTIVEP is t when gptel is called interactively."
   (interactive
    (let* ((backend (default-value 'gptel-backend))
           (backend-name
-           (format "*%s*" (gptel-backend-name backend)))
-          (gptel-bufs
-           (seq-filter
-            (lambda (buf) (buffer-local-value 'gptel-mode buf))
-            (buffer-list))))
+           (format "*%s*" (gptel-backend-name backend))))
      (list (if current-prefix-arg
                (read-string "Session name: "
                             (generate-new-buffer-name
                              backend-name))
-             (if (> (length gptel-bufs) 1)
-                 (completing-read "Choose Gptel buffer: "
-                                  (mapcar #'buffer-name gptel-bufs)
-                                  nil 'confirm)
-               backend-name))
+             (read-buffer "Create or choose gptel buffer: "
+                          backend-name nil                         ; DEFAULT and REQUIRE-MATCH
+                          (lambda (b)                              ; PREDICATE
+                            (buffer-local-value 'gptel-mode
+                                                (get-buffer (or (car-safe b) b))))))
            (condition-case nil
                (gptel--get-api-key
                 (gptel-backend-key backend))

--- a/gptel.el
+++ b/gptel.el
@@ -1201,11 +1201,6 @@ If SHOOSH is true, don't issue a warning."
 (defun gptel (name &optional _ initial interactivep)
   "Switch to or start a chat session with NAME.
 
-If called interactively when multiple gptel buffers exist, ask the user
-which buffer to switch to.
-
-With a prefix arg, query for a (new) session name.
-
 Ask for API-KEY if `gptel-api-key' is unset.
 
 If region is active, use it as the INITIAL prompt.  Returns the

--- a/gptel.el
+++ b/gptel.el
@@ -1230,7 +1230,7 @@ INTERACTIVEP is t when gptel is called interactively."
                             (generate-new-buffer-name
                              backend-name))
              (if (> (length gptel-bufs) 1)
-                 (completing-read "Choose Gptel buffer: " (mapcar #'buffer-name gptel-bufs))
+                 (completing-read "Choose Gptel buffer: " (mapcar #'buffer-name gptel-bufs) nil "confirm")
                backend-name))
            (condition-case nil
                (gptel--get-api-key

--- a/gptel.el
+++ b/gptel.el
@@ -1216,15 +1216,11 @@ INTERACTIVEP is t when gptel is called interactively."
    (let* ((backend (default-value 'gptel-backend))
           (backend-name
            (format "*%s*" (gptel-backend-name backend))))
-     (list (if current-prefix-arg
-               (read-string "Session name: "
-                            (generate-new-buffer-name
-                             backend-name))
-             (read-buffer "Create or choose gptel buffer: "
-                          backend-name nil                         ; DEFAULT and REQUIRE-MATCH
-                          (lambda (b)                              ; PREDICATE
-                            (buffer-local-value 'gptel-mode
-                                                (get-buffer (or (car-safe b) b))))))
+     (list (read-buffer "Create or choose gptel buffer: "
+                        backend-name nil                         ; DEFAULT and REQUIRE-MATCH
+                        (lambda (b)                              ; PREDICATE
+                          (buffer-local-value 'gptel-mode
+                                              (get-buffer (or (car-safe b) b)))))
            (condition-case nil
                (gptel--get-api-key
                 (gptel-backend-key backend))

--- a/gptel.el
+++ b/gptel.el
@@ -1230,7 +1230,9 @@ INTERACTIVEP is t when gptel is called interactively."
                             (generate-new-buffer-name
                              backend-name))
              (if (> (length gptel-bufs) 1)
-                 (completing-read "Choose Gptel buffer: " (mapcar #'buffer-name gptel-bufs) nil "confirm")
+                 (completing-read "Choose Gptel buffer: "
+                                  (mapcar #'buffer-name gptel-bufs)
+                                  nil 'confirm)
                backend-name))
            (condition-case nil
                (gptel--get-api-key


### PR DESCRIPTION
This commit modifies the behavior of the gptel function so that, in the case where the function is called interactively, and multiple gptel sessions already exist (as judged by there being multiple buffers with the minor mode gptel-mode enabled), then the function prompts the user to select one of those buffers.

This replaces the previous behavior in this case, which was just to switch to the buffer named `backend-name` if it already existed, or else to create a new buffer with that name.

So, after this comit, the gptel function behaves as follows:

- (NEW). When called interactively and multiple gptel-mode buffers exists, it prompts the user to choose a buffer to switch to.

- when called interactively and no gptel-mode buffers exist, it creates a buffer named `backend-name`

- when called interactively and 1 gptel-mode buffers exists, it switches to the buffer named `backend-name` or creates it if it does not exist.

- when called interactively with a prefix arg, it behaves as before, and prompts the user to acknowledge or input the name of a buffer to create.

- when called programmatically, it behaves as before.