### PR TITLE
Support for privateGPT, including support for RAG functions like rspecting context and parsing of sources

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,23 +4,24 @@
 
 gptel is a simple Large Language Model chat client for Emacs, with support for multiple models and backends.
 
-| LLM Backend        | Supports | Requires                  |
-|--------------------+----------+---------------------------|
-| ChatGPT            | ✓      | [[https://platform.openai.com/account/api-keys][API key]]                   |
-| Azure              | ✓      | Deployment and API key    |
-| Ollama             | ✓      | [[https://ollama.ai/][Ollama running locally]]    |
-| GPT4All            | ✓      | [[https://gpt4all.io/index.html][GPT4All running locally]]   |
-| Gemini             | ✓      | [[https://makersuite.google.com/app/apikey][API key]]                   |
-| Llama.cpp          | ✓      | [[https://github.com/ggerganov/llama.cpp/tree/master/examples/server#quick-start][Llama.cpp running locally]] |
-| Llamafile          | ✓      | [[https://github.com/Mozilla-Ocho/llamafile#quickstart][Local Llamafile server]]    |
-| Kagi FastGPT       | ✓      | [[https://kagi.com/settings?p=api][API key]]                   |
-| Kagi Summarizer    | ✓      | [[https://kagi.com/settings?p=api][API key]]                   |
-| together.ai        | ✓      | [[https://api.together.xyz/settings/api-keys][API key]]                   |
-| Anyscale           | ✓      | [[https://docs.endpoints.anyscale.com/][API key]]                   |
-| Perplexity         | ✓      | [[https://docs.perplexity.ai/docs/getting-started][API key]]                   |
-| Anthropic (Claude) | ✓      | [[https://www.anthropic.com/api][API key]]                   |
-| Groq               | ✓      | [[https://console.groq.com/keys][API key]]                          |
-| OpenRouter         | ✓      | [[https://openrouter.ai/keys][API key]]                          |
+| LLM Backend        | Supports | Requires                   |
+|--------------------+----------+----------------------------|
+| ChatGPT            | ✓        | [[https://platform.openai.com/account/api-keys][API key]]                    |
+| Azure              | ✓        | Deployment and API key     |
+| Ollama             | ✓        | [[https://ollama.ai/][Ollama running locally]]     |
+| GPT4All            | ✓        | [[https://gpt4all.io/index.html][GPT4All running locally]]    |
+| Gemini             | ✓        | [[https://makersuite.google.com/app/apikey][API key]]                    |
+| Llama.cpp          | ✓        | [[https://github.com/ggerganov/llama.cpp/tree/master/examples/server#quick-start][Llama.cpp running locally]]  |
+| Llamafile          | ✓        | [[https://github.com/Mozilla-Ocho/llamafile#quickstart][Local Llamafile server]]     |
+| Kagi FastGPT       | ✓        | [[https://kagi.com/settings?p=api][API key]]                    |
+| Kagi Summarizer    | ✓        | [[https://kagi.com/settings?p=api][API key]]                    |
+| together.ai        | ✓        | [[https://api.together.xyz/settings/api-keys][API key]]                    |
+| Anyscale           | ✓        | [[https://docs.endpoints.anyscale.com/][API key]]                    |
+| Perplexity         | ✓        | [[https://docs.perplexity.ai/docs/getting-started][API key]]                    |
+| Anthropic (Claude) | ✓        | [[https://www.anthropic.com/api][API key]]                    |
+| Groq               | ✓        | [[https://console.groq.com/keys][API key]]                    |
+| OpenRouter         | ✓        | [[https://openrouter.ai/keys][API key]]                    |
+| PrivateGPT         | ✓        | [[https://github.com/zylon-ai/private-gpt#-documentation][PrivateGPT running locally]] |
 
 *General usage*: ([[https://www.youtube.com/watch?v=bsRnh_brggM][YouTube Demo]])
 
@@ -63,6 +64,7 @@ gptel uses Curl if available, but falls back to url-retrieve to work without ext
       - [[#anthropic-claude][Anthropic (Claude)]]
       - [[#groq][Groq]]
       - [[#openrouter][OpenRouter]]
+      - [[#privategpt][PrivateGPT]]
   - [[#usage][Usage]]
     - [[#in-any-buffer][In any buffer:]]
     - [[#in-a-dedicated-chat-buffer][In a dedicated chat buffer:]]
@@ -552,6 +554,41 @@ The above code makes the backend available to select.  If you want it to be the 
                   "codellama/codellama-70b-instruct"
                   "google/palm-2-codechat-bison-32k"
                   "google/gemini-pro")))
+
+#+end_src
+
+#+html: </details>
+**** PrivateGPT
+#+html: </summary>
+
+Register a backend with
+#+begin_src emacs-lisp
+(gptel-make-privategpt "privateGPT"               ;Any name you want
+  :protocol "http"
+  :host "localhost:8001"
+  :stream t
+  :context t                            ;Use context provided by embeddings
+  :sources t                            ;Return information about source documents
+  :models '("private-gpt"))
+
+#+end_src
+
+You can pick this backend from the menu when using gptel (see [[#usage][Usage]]).
+
+***** (Optional) Set as the default gptel backend
+
+The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.
+#+begin_src emacs-lisp
+;; OPTIONAL configuration
+(setq gptel-model   "private-gpt"
+      gptel-backend
+      (gptel-make-privategpt "privateGPT"               ;Any name you want
+        :protocol "http"
+        :host "localhost:8001"
+        :stream t
+        :context t                            ;Use context provided by embeddings
+        :sources t                            ;Return information about source documents
+        :models '("private-gpt")))
 
 #+end_src
 

--- a/gptel-privategpt.el
+++ b/gptel-privategpt.el
@@ -1,0 +1,163 @@
+;;; gptel-privategpt.el ---  Privategpt AI suppport for gptel  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2023  Karthik Chikmagalur
+
+;; Author: Karthik Chikmagalur <karthikchikmagalur@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file adds support for Privategpt's Messages API to gptel
+
+;;; Code:
+(require 'cl-generic)
+(eval-when-compile
+  (require 'cl-lib))
+(require 'map)
+(require 'gptel)
+
+(defvar json-object-type)
+
+(declare-function prop-match-value "text-property-search")
+(declare-function text-property-search-backward "text-property-search")
+(declare-function json-read "json" ())
+
+
+
+;;; Privategpt (Messages API)
+(cl-defstruct (gptel-privategpt (:constructor gptel--make-privategpt)
+                               (:copier nil)
+                               (:include gptel-openai))
+  context sources)
+
+(defun gptel--privategpt-parse-sources (response)
+  (cl-loop with source-alist
+           for source across (map-nested-elt response '(:choices 0 :sources))
+           for name = (map-nested-elt source '(:document :doc_metadata :file_name))
+           for page = (map-nested-elt source '(:document :doc_metadata :page_label))
+           do (push page (alist-get name source-alist nil nil #'equal))
+           finally return
+           (cl-loop for (file-name . file-pages) in source-alist
+                    for pages = (delete-dups (delq nil file-pages))
+                    if pages
+                    collect (format "- %s (page %s)" file-name (mapconcat #'identity pages ", "))
+                    into source-items
+                    else collect (format "- %s" file-name) into source-items
+                    finally return (mapconcat #'identity (cons "\n\nSources:" source-items) "\n"))))
+
+(cl-defmethod gptel-curl--parse-stream ((_backend gptel-privategpt) info)
+  (let* ((content-strs))
+    (condition-case nil
+        (while (re-search-forward "^data:" nil t)
+          (save-match-data
+            (if (looking-at " *\\[DONE\\]")
+                (when-let ((sources-string (plist-get info :sources)))
+                  (push sources-string content-strs))
+              (let ((response (gptel--json-read)))
+		(unless (or (plist-get info :sources)
+                            (not (gptel-privategpt-sources (plist-get info :backend))))
+                  (plist-put info :sources (gptel--privategpt-parse-sources response)))
+		(let* ((delta (map-nested-elt response '(:choices 0 :delta)))
+		       (content (plist-get delta :content)))
+		  (push content content-strs))))))
+    (error
+     (goto-char (match-beginning 0))))
+  (apply #'concat (nreverse content-strs))))
+
+(cl-defmethod gptel--parse-response ((_backend gptel-privategpt) response info)
+  (let ((response-string (map-nested-elt response '(:choices 0 :message :content)))
+        (sources-string (and (gptel-privategpt-sources (plist-get info :backend))
+                             (gptel--privategpt-parse-sources response))))
+    (concat response-string sources-string)))
+
+(cl-defmethod gptel--request-data ((_backend gptel-privategpt) prompts)
+  "JSON encode PROMPTS for sending to ChatGPT."
+  (let ((prompts-plist
+         `(:model ,gptel-model
+	   :messages [,@prompts]
+	   :use_context ,(or (gptel-privategpt-context gptel-backend) :json-false)
+	   :include_sources ,(or (gptel-privategpt-sources gptel-backend) :json-false)
+           :stream ,(or (and gptel-stream gptel-use-curl
+                         (gptel-backend-stream gptel-backend))
+                     :json-false))))
+    (when gptel-temperature
+      (plist-put prompts-plist :temperature gptel-temperature))
+    (when gptel-max-tokens
+      (plist-put prompts-plist :max_tokens gptel-max-tokens))
+    prompts-plist))
+
+
+;;;###autoload
+(cl-defun gptel-make-privategpt
+    (name &key curl-args stream key
+          (header
+           (lambda () (when-let (key (gptel--get-api-key))
+			`(("Authorization" . ,(concat "Bearer " key))))))
+          (host "localhost:8001")
+          (protocol "http")
+	  (models '("private-gpt"))
+          (endpoint "/v1/chat/completions")
+          (context t) (sources t))
+  "Register an Privategpt API-compatible backend for gptel with NAME.
+
+Keyword arguments:
+
+CURL-ARGS (optional) is a list of additional Curl arguments.
+
+HOST (optional) is the API host, \"api.privategpt.com\" by default.
+
+MODELS is a list of available model names.
+
+STREAM is a boolean to toggle streaming responses, defaults to
+false.
+
+PROTOCOL (optional) specifies the protocol, https by default.
+
+ENDPOINT (optional) is the API endpoint for completions, defaults to
+\"/v1/messages\".
+
+HEADER (optional) is for additional headers to send with each
+request. It should be an alist or a function that retuns an
+alist, like:
+((\"Content-Type\" . \"application/json\"))
+
+KEY is a variable whose value is the API key, or function that
+returns the key.
+
+CONTEXT and SOURCES: if true (the default), use available context
+and provide sources used by the model to generate the response."
+  (declare (indent 1))
+  (let ((backend (gptel--make-privategpt
+                  :curl-args curl-args
+                  :name name
+                  :host host
+                  :header header
+                  :key key
+                  :models models
+                  :protocol protocol
+                  :endpoint endpoint
+                  :stream stream
+                  :url (if protocol
+                           (concat protocol "://" host endpoint)
+                         (concat host endpoint))
+                  :context context
+                  :sources sources)))
+    (prog1 backend
+      (setf (alist-get name gptel--known-backends
+                       nil nil #'equal)
+                  backend))))
+
+(provide 'gptel-privategpt)
+;;; gptel-backends.el ends here


### PR DESCRIPTION
Hi, as suggested in our recent discussion #305, here's a PR that adds support for interacting with privateGPT. Its based on the openai-backend, with some additions. The focus was to enable the use of two specific key words, as described in the [API reference](https://docs.privategpt.dev/api-reference/api-reference/contextual-completions/chat-completion-v-1-chat-completions-post-stream):
1) `use_context`: directs the LLM to use the context of documents that have been "ingested"
2) `include_sources`: directs the LLM to also return information about the sources of the context (so far: file name and page number, if appropriate).

I changed the code of `gptel-openai.el`to send the additional keywords to the llm server, and to correctly parse the answer if sources are provided. 

I tested the code with different queries, and so far it works for my use case. However, there is at least one missing feature: currently, the two new keywords `use_context` and `include_sources` are hardcoded to `t`. It would probably be better to make them configurable when creating the backend. Unfortunately, I'm not sure how to do that correctly.