### PR TITLE
Add new model: GPT-4o

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -401,6 +401,7 @@ The current options for ChatGPT are
 - \"gpt-3.5-turbo\"
 - \"gpt-3.5-turbo-16k\"
 - \"gpt-4\"
+- \"gpt-4o\"
 - \"gpt-4-turbo\"
 - \"gpt-4-turbo-preview\"
 - \"gpt-4-32k\"
@@ -414,6 +415,7 @@ To set the model for a chat session interactively call
           (const :tag "GPT 3.5 turbo" "gpt-3.5-turbo")
           (const :tag "GPT 3.5 turbo 16k" "gpt-3.5-turbo-16k")
           (const :tag "GPT 4" "gpt-4")
+          (const :tag "GPT 4 Omni" "gpt-4o")
           (const :tag "GPT 4 turbo" "gpt-4-turbo")
           (const :tag "GPT 4 turbo (preview)" "gpt-4-turbo-preview")
           (const :tag "GPT 4 32k" "gpt-4-32k")
@@ -444,9 +446,9 @@ with differing settings.")
    "ChatGPT"
    :key 'gptel-api-key
    :stream t
-   :models '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4-turbo"
-             "gpt-4-turbo-preview" "gpt-4-32k" "gpt-4-1106-preview"
-             "gpt-4-0125-preview")))
+   :models '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4" "gpt-4o"
+             "gpt-4-turbo" "gpt-4-turbo-preview" "gpt-4-32k"
+             "gpt-4-1106-preview" "gpt-4-0125-preview")))
 
 (defcustom gptel-backend gptel--openai
   "LLM backend to use.

--- a/gptel.el
+++ b/gptel.el
@@ -415,7 +415,7 @@ To set the model for a chat session interactively call
           (const :tag "GPT 3.5 turbo" "gpt-3.5-turbo")
           (const :tag "GPT 3.5 turbo 16k" "gpt-3.5-turbo-16k")
           (const :tag "GPT 4" "gpt-4")
-          (const :tag "GPT 4 Omni" "gpt-4o")
+          (const :tag "GPT 4 omni" "gpt-4o")
           (const :tag "GPT 4 turbo" "gpt-4-turbo")
           (const :tag "GPT 4 turbo (preview)" "gpt-4-turbo-preview")
           (const :tag "GPT 4 32k" "gpt-4-32k")


### PR DESCRIPTION
OpenAI has released a new model called GPT-4o, or "GPT-4 Omni". More information [here](https://openai.com/index/hello-gpt-4o/).