### PR TITLE
new flag introduced: it forces prompt context that is sent to backend, be more explicit

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -114,6 +114,12 @@ This makes it feasible to have multiple conversation branches."
   :type 'boolean
   :group 'gptel)
 
+(defcustom gptel-org-force-branching-context-with-topic nil
+  "force the existence both the topic and branching context"
+  :local t
+  :type 'boolean
+  :group 'gptel)
+
 
 ;;; Setting context and creating queries
 (defun gptel-org--get-topic-start ()
@@ -158,9 +164,11 @@ value of `gptel-org-branching-context', which see."
   (let ((max-entries (and gptel--num-messages-to-send
                           (* 2 gptel--num-messages-to-send)))
         (topic-start (gptel-org--get-topic-start)))
-    (when topic-start
-      ;; narrow to GPTEL_TOPIC property scope
-      (narrow-to-region topic-start prompt-end))
+    (if topic-start
+        ;; narrow to GPTEL_TOPIC property scope
+        (narrow-to-region topic-start prompt-end)
+      (when gptel-org-force-branching-context-with-topic
+        (error "topic forced but non-existent")))
     (if gptel-org-branching-context
         ;; Create prompt from direct ancestors of point
         (if (fboundp 'org-element-lineage-map)
@@ -203,6 +211,8 @@ value of `gptel-org-branching-context', which see."
              '(gptel org)
              "Using `gptel-org-branching-context' requires Org version 9.6.7 or higher, it will be ignored.")
           (gptel--parse-buffer gptel-backend max-entries))
+      (when gptel-org-force-branching-context-with-topic
+        (error "branching context forced but non-existent"))
       ;; Create prompt the usual way
       (gptel--parse-buffer gptel-backend max-entries))))
 

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -114,12 +114,6 @@ This makes it feasible to have multiple conversation branches."
   :type 'boolean
   :group 'gptel)
 
-(defcustom gptel-org-force-branching-context-with-topic nil
-  "force the existence both the topic and branching context"
-  :local t
-  :type 'boolean
-  :group 'gptel)
-
 
 ;;; Setting context and creating queries
 (defun gptel-org--get-topic-start ()
@@ -167,8 +161,9 @@ value of `gptel-org-branching-context', which see."
     (if topic-start
         ;; narrow to GPTEL_TOPIC property scope
         (narrow-to-region topic-start prompt-end)
-      (when gptel-org-force-branching-context-with-topic
-        (error "topic forced but non-existent")))
+      (when (and gptel-force-prompt-context-be-explicit (buffer-file-name))
+        (error "explicit prompt context forced but org's topic not present
+ along hierarchical lineage of the current Org heading")))
     (if gptel-org-branching-context
         ;; Create prompt from direct ancestors of point
         (if (fboundp 'org-element-lineage-map)
@@ -211,8 +206,8 @@ value of `gptel-org-branching-context', which see."
              '(gptel org)
              "Using `gptel-org-branching-context' requires Org version 9.6.7 or higher, it will be ignored.")
           (gptel--parse-buffer gptel-backend max-entries))
-      (when gptel-org-force-branching-context-with-topic
-        (error "branching context forced but non-existent"))
+      (when (and gptel-force-prompt-context-be-explicit (buffer-file-name))
+        (error "explicit prompt context forced but org's branching context is not set"))
       ;; Create prompt the usual way
       (gptel--parse-buffer gptel-backend max-entries))))
 

--- a/gptel.el
+++ b/gptel.el
@@ -514,6 +514,19 @@ with `gptel-mode' enabled), where user prompts and responses are
 always handled separately."
   :type 'boolean)
 
+(defcustom gptel-force-prompt-context-be-explicit nil
+  "Force the context that is sent along the prompt be explicitly bound.
+
+If non-nil, then:
+For Org mode's FILE buffers: `gptel-org-branching-context' must be non-nil
+                              and conversation topic needs to be present
+                              in hierarchical lineage of the current Org
+                              heading.
+For other buffers: region must be marked."
+  :local t
+  :type 'boolean
+  :group 'gptel)
+
 (defvar-local gptel--old-header-line nil)
 
 
@@ -1050,8 +1063,11 @@ there."
          ((derived-mode-p 'org-mode)
           (require 'gptel-org)
           (gptel-org--create-prompt (or prompt-end (point-max))))
-         (t (goto-char (or prompt-end (point-max)))
-            (gptel--parse-buffer gptel-backend max-entries)))))))
+         (t
+          (when gptel-force-prompt-context-be-explicit
+            (error "explicit prompt context forced but region is NOT marked"))
+          (goto-char (or prompt-end (point-max)))
+          (gptel--parse-buffer gptel-backend max-entries)))))))
 
 (cl-defgeneric gptel--parse-buffer (backend max-entries)
   "Parse current buffer backwards from point and return a list of prompts.


### PR DESCRIPTION
@karthink, thank you very much for the great gptel package. It's great value is noticeable.

I'm issuing PR to prevent users from accidental sending too many data during requesting from org mode buffer.

The idea is to force both branching and topic be present on the path. If they both are included, then one may assume the user set these two intentionally thus sends that part of buffer (s)he wants.

the setting by default is nil (nothing changes to existing users), but IMO it may be considered to be set to true as default.

please let me know what you think about the change.

kind regards,
Vibrys