### PR TITLE
Clean up response before ediffing

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -100,7 +100,7 @@ Or is it the other way around?"
 (defun gptel--rewrite-message ()
   "Set a generic refactor/rewrite message for the buffer."
   (if (derived-mode-p 'prog-mode)
-      (format "You are a %s programmer. Refactor the following code. Generate only code, no explanation."
+      (format "You are a %s programmer. Refactor the following code. Generate only code, no explanation, no code fences."
               (gptel--strip-mode-suffix major-mode))
     (format "You are a prose editor. Rewrite the following text to be more professional.")))
 


### PR DESCRIPTION
ChatGPT response contains three backticks with programming language name at the first and last lines which prevents ediff from working properly.

Fixes #344