### PR TITLE
Add basic OpenAI vision support

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -306,6 +306,7 @@ Also format its value in the Transient menu."
      :if (lambda () (or gptel-mode gptel-track-response)))
     (gptel--infix-temperature :if (lambda () gptel-expert-commands))
     (gptel--infix-use-context)
+    (gptel--infix-use-image)
     (gptel--infix-track-response
      :if (lambda () (and gptel-expert-commands (not gptel-mode))))]
    ["Prompt from"
@@ -505,6 +506,27 @@ value of `gptel-use-context', set from here."
                               ("with user prompt"    . user)))
                    (destination (completing-read prompt choices nil t)))
               (cdr (assoc destination choices)))))
+
+;; ** Infixes for prompt images
+
+(transient-define-infix gptel--infix-use-image ()
+  "Image to be used for vision models."
+  :description "With image"
+  :class 'gptel-lisp-variable
+  :variable 'gptel-image
+  :set-value #'gptel--set-with-scope
+  :key "-p"
+  :prompt "Path or URL to image: "
+  :display-nil "No"
+  :reader (lambda (prompt &rest _)
+            (let ((image (completing-read-default prompt
+                                                  nil
+                                                  nil
+                                                  nil
+                                                  (or gptel-image default-directory))))
+              (if (string-empty-p (string-trim image))
+                  nil
+                image))))
 
 ;; ** Infixes for model parameters
 

--- a/gptel.el
+++ b/gptel.el
@@ -446,6 +446,17 @@ To set the temperature for a chat session interactively call
   :safe #'always
   :type 'number)
 
+(defcustom gptel-image nil
+  "An image that is sent to the vision-based LLM models as part of the prompt.
+
+Should be a valid pathname to an image.
+
+To set the image for a chat session interactively call
+`gptel-send' with a prefix argument."
+  :safe #'always
+  :type 'string)
+
+
 (defvar gptel--known-backends)
 
 (defvar gptel--openai
@@ -704,7 +715,15 @@ MODE-NAME is typically a major-mode symbol."
          mode-sym 'prog-mode 'text-mode 'tex-mode)
      mode-name "")))
 
-
+(defun gptel--base64-encode (file)
+  "Encode FILE as a base64 string.
+
+FILE is assumed to exist and be a regular file."
+  (with-temp-buffer
+    (insert-file-contents-literally file)
+    (base64-encode-region (point-min) (point-max))
+    (buffer-string)))
+
 ;; Logging
 
 (defconst gptel--log-buffer-name "*gptel-log*"


### PR DESCRIPTION
I found myself requiring the use of vision models sometimes because it would otherwise be very unwieldy to describe my problem in text. I kept retreating back to the online interfaces where a lot of them don't even allow you to paste the images directly, and instead force you to first save and upload them.

There's a [feature branch](https://github.com/karthink/gptel/tree/feature-vision) which adds OpenAI vision features based on the discussion in https://github.com/karthink/gptel/discussions/231 to org-mode, but its only usable via org-mode and in the dedicated chatting buffer.

This adds a transient menu option to send the model a one-time image:

![image](https://github.com/user-attachments/assets/ff674bb3-962b-4c34-8bb1-a82aa24cda42)

To make this multi-modal, I had to forfeit ability to track image history, so you can only have one image "known" at a time.

I don't consider it a big limitation considering the usefulness. I wrote a small script to be able to send it disposable clipboard images, and here's how it looks like:

https://github.com/user-attachments/assets/57c38d81-e676-4d2b-82e3-c3464bf2b84f

https://github.com/user-attachments/assets/9fe36f20-ea65-4cf3-8071-3b9a28fc00bd

I only touched the OpenAI backend. There's currently no indication for the lack of support in the other ones.

The image can be a regular local image or a URL to one.

I didn't give too much thought to how it would fit inside the transient menu layout, so that would probably need to be adjusted (I also think now that `-I` would work much better for it than `-p`).

Extremely long image filenames look clunky as they drive away the rest of the transient columns. A new variable type needs to be created?