### PR TITLE
Utilizing the original buffer as ediff buffer in eglot-mode

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1046,6 +1046,7 @@ When LOCAL is non-nil, set the system message only in the current buffer."
             (lambda ()
               (when (window-configuration-p cwc)
                 (set-window-configuration cwc))
+              (ediff-kill-buffer-carefully "*gptel-rewrite-Region.B-*")
               (remove-hook 'ediff-quit-hook gptel--ediff-restore))))
     (message "Waiting for response... ")
     (gptel-request
@@ -1071,7 +1072,9 @@ When LOCAL is non-nil, set the system message only in the current buffer."
              (add-hook 'ediff-quit-hook gptel--ediff-restore)
              (apply
               #'ediff-regions-internal
-              (get-buffer (ediff-make-cloned-buffer gptel-buffer "-Region.A-"))
+              (if (and (require 'eglot nil t) (eglot-managed-p))
+                  gptel-buffer
+                (get-buffer (ediff-make-cloned-buffer gptel-buffer "-Region.A-")))
               (car gptel-bounds) (cdr gptel-bounds)
               new-buf new-beg new-end
               nil


### PR DESCRIPTION
Eglot employs track-changes to monitor buffer modifications. However, track-changes is unable to account for cloned buffers, resulting in inaccurate status updates when changes occur in a cloned buffer.

This patch directly uses the original buffer in ediff mode, effectively resolving the issue. While this approach narrows the buffer, potentially causing confusion for some users, the buffer is restored to its original state after exiting ediff.