### PR TITLE
Fix gptel-context-add handling of region boundary when choosing a buffer

### DIFF
--- a/gptel-context.el
+++ b/gptel-context.el
@@ -111,9 +111,11 @@ context chunk.  This is accessible as, for example:
           (dired-get-marked-files)))
    ;; No region is selected, and ARG is positive.
    ((and arg (> (prefix-numeric-value arg) 0))
-    (let ((buffer-name (read-buffer "Choose buffer to add as context: " nil t)))
+    (let* ((buffer-name (read-buffer "Choose buffer to add as context: " nil t))
+           (start (with-current-buffer buffer-name (point-min)))
+           (end (with-current-buffer buffer-name (point-max))))
       (gptel-context--add-region
-       (get-buffer buffer-name) (point-min) (point-max) t)
+       (get-buffer buffer-name) start end t)
       (message "Buffer '%s' added as context." buffer-name)))
    ;; No region is selected, and ARG is negative.
    ((and arg (< (prefix-numeric-value arg) 0))


### PR DESCRIPTION
When gptel-context-add was called with a positive prefix argument to select a buffer to add to the context, it was using `point-min` and `point-max` of the _current buffer_ to determine the region of context, instead of the target buffer. This meant the context didn't contain the whole target buffer. The fix is straightforward: just make sure to use the target buffer's `point-min` and `point-max` instead.