### PR TITLE
Change order of Refactor sentences in gptel--rewrite-message

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -100,7 +100,7 @@ Or is it the other way around?"
 (defun gptel--rewrite-message ()
   "Set a generic refactor/rewrite message for the buffer."
   (if (derived-mode-p 'prog-mode)
-      (format "You are a %s programmer. Refactor the following code. Generate only code, no explanation, no code fences."
+      (format "You are a %s programmer. Generate only code, no explanation, no code fences. Refactor the following code."
               (gptel--strip-mode-suffix major-mode))
     (format "You are a prose editor. Rewrite the following text to be more professional.")))
 


### PR DESCRIPTION
This change I believe is more useful for a typical user in the following common use case

I as a user would like not to refactor but to rewrite in a specific way mentioning what is important. With the existing default prompt I need to formulate it like "Refactor/rewrite in a way that {details}" repeating "Refactor" twice in different places. With "Refactor the following code." being a suffix, I just need to press Backspace once removing dot and start typing {details} right away.

"Generate only code, no explanation" chunk is a part that rarely gets updated so it might be better to keep it in the middle because users won't need to access it often.