### PR TITLE
Add ChatGPT o1-preview and o1-mini

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -419,12 +419,16 @@ The current options for ChatGPT are
 - \"gpt-4-turbo-preview\"
 - \"gpt-4-32k\"
 - \"gpt-4-1106-preview\"
+- \"o1-preview\"
+- \"o1-mini\"
 
 To set the model for a chat session interactively call
 `gptel-send' with a prefix argument."
   :safe #'always
   :type '(choice
           (string :tag "Specify model name")
+          (const :tag "o1 (preview)" "o1-preview")
+          (const :tag "o1 mini" "o1-mini")
           (const :tag "GPT 4 omni mini" "gpt-4o-mini")
           (const :tag "GPT 3.5 turbo" "gpt-3.5-turbo")
           (const :tag "GPT 3.5 turbo 16k" "gpt-3.5-turbo-16k")
@@ -455,7 +459,8 @@ To set the temperature for a chat session interactively call
    :stream t
    :models '("gpt-3.5-turbo" "gpt-3.5-turbo-16k" "gpt-4o-mini"
              "gpt-4" "gpt-4o" "gpt-4-turbo" "gpt-4-turbo-preview"
-             "gpt-4-32k" "gpt-4-1106-preview" "gpt-4-0125-preview")))
+             "gpt-4-32k" "gpt-4-1106-preview" "gpt-4-0125-preview"
+             "o1-preview" "o1-mini")))
 
 (defcustom gptel-backend gptel--openai
   "LLM backend to use.


### PR DESCRIPTION
## About

Add new models of ChatGPT
- `o1-preview`
- `o1-mini`

Ref. https://platform.openai.com/docs/models/o1

## Note

My account couldn't use these models yet.
I have not been able to test these codes.