### PR TITLE
Binding RET to gptel-return-dwim, don't need press C-c to send prompt.

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -830,6 +830,7 @@ file."
   :keymap
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c RET") #'gptel-send)
+    (define-key map (kbd "RET") #'gptel-return-dwim)
     map)
   (if gptel-mode
       (progn
@@ -1071,6 +1072,18 @@ waiting for the response."
   (gptel--sanitize-model)
   (gptel-request nil :stream gptel-stream)
   (gptel--update-status " Waiting..." 'warning)))
+
+;;;###autoload
+(defun gptel-return-dwim (&optional arg)
+  "If cursor at prompt line, call `gptel-send', otherwise call RET function."
+  (interactive "P")
+  (let ((in-prompt-line-p
+         (save-excursion
+           (beginning-of-line)
+           (search-forward-regexp "^#+\\s-" (line-end-position) t))))
+    (if in-prompt-line-p
+        (gptel-send arg)
+      (call-interactively (key-binding (kbd "C-m"))))))
 
 (declare-function json-pretty-print-buffer "json")
 (defun gptel--inspect-query (request-data &optional arg)


### PR DESCRIPTION
Hi, I've added a gptel-return-dwim function today, which will detect every time you press the RET key, execute gptel-send if it starts with #,  otherwise call the RET function

In this way, we can just press RET for normal use, and we don't need to press the C-c prefix button every time