### PR TITLE
[tests] Refactor tests (explicit require, no byte-compile)

### DIFF
--- a/test/gptel-org-test.el
+++ b/test/gptel-org-test.el
@@ -1,6 +1,7 @@
 ;; -*- lexical-binding: t; -*-
 (require 'ert)
 (require 'gptel)
+(require 'gptel-org)
 (require 'cl-generic)
 
 (declare-function json-read "json" ())

--- a/test/gptel-org-test.el
+++ b/test/gptel-org-test.el
@@ -1,4 +1,4 @@
-;; -*- lexical-binding: t; -*-
+;; -*- lexical-binding: t; no-byte-compile: t; -*-
 (require 'ert)
 (require 'gptel)
 (require 'gptel-org)


### PR DESCRIPTION
* 3e50928 2024-refactor-tests origin/2024-refactor-tests chore(test/gptel-org-test): turn off byte-compiling for tests
* 937c3a0 fix(test/gptel-org-test): explicitly require needed gptel-org
