### PR TITLE
Allow for prepending (instead of appending) context to the system message

### DIFF
--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -101,7 +101,7 @@
             prompts))
     prompts))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-anthropic) prompts)
+(cl-defmethod gptel--wrap-last-user-prompt ((_backend gptel-anthropic) prompts)
   "Wrap the last user prompt in PROMPTS with the context string."
   (cl-callf gptel-context--wrap (plist-get (car (last prompts)) :content)))
 

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -208,14 +208,14 @@ If selection is active, removes all contexts within selection."
 
 MESSAGE is usually either the system message or the last user prompt.
 The accumulated context from CONTEXTS is appended or prepended to
-it, respectively."
-  ;; Append context before/after system message.
+it, as requested."
   (let ((context-string (gptel-context--string contexts)))
     (if (> (length context-string) 0)
         (pcase-exhaustive gptel-use-context
-          ('system (concat message "\n\n" context-string))
-          ('user   (concat context-string "\n\n" message))
-          ('nil    message))
+          ('system         (concat message "\n\n" context-string))
+          ('system-prepend (concat context-string "\n\n" message))
+          ('user           (concat context-string "\n\n" message))
+          ('nil            message))
       message)))
 
 (cl-defun gptel-context--add-region (buffer region-beginning region-end &optional advance)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -206,7 +206,7 @@ If selection is active, removes all contexts within selection."
 (defun gptel-context--wrap-default (message contexts)
   "Add CONTEXTS to MESSAGE.
 
-MESSAGE is usually either the system message or the user prompt.
+MESSAGE is usually either the system message or the last user prompt.
 The accumulated context from CONTEXTS is appended or prepended to
 it, respectively."
   ;; Append context before/after system message.

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -124,7 +124,7 @@
                         (plist-get :text))))
     prompts))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-gemini) prompts)
+(cl-defmethod gptel--wrap-last-user-prompt ((_backend gptel-gemini) prompts)
   "Wrap the last user prompt in PROMPTS with the context string."
   (cl-callf gptel-context--wrap
       (plist-get (plist-get (car (last prompts)) :parts) :text)))

--- a/gptel-kagi.el
+++ b/gptel-kagi.el
@@ -123,7 +123,7 @@
                      ""))))
           prompts)))))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-kagi) prompts)
+(cl-defmethod gptel--wrap-last-user-prompt ((_backend gptel-kagi) prompts)
   (cond
    ((plist-get prompts :url)
     (message "Ignoring gptel context for URL summary request."))

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -123,7 +123,7 @@ Intended for internal use only.")
                 :content gptel--system-message)
           prompts)))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-ollama) prompts)
+(cl-defmethod gptel--wrap-last-user-prompt ((_backend gptel-ollama) prompts)
   "Wrap the last user prompt in PROMPTS with the context string."
   (cl-callf gptel-context--wrap (plist-get (car (last prompts)) :content)))
 

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -158,7 +158,7 @@ with differing settings.")
                 :content gptel--system-message)
           prompts)))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-openai) prompts)
+(cl-defmethod gptel--wrap-last-user-prompt ((_backend gptel-openai) prompts)
   "Wrap the last user prompt in PROMPTS with the context string."
   (cl-callf gptel-context--wrap (plist-get (car (last prompts)) :content)))
 

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -326,8 +326,10 @@ the changed regions. BUF is the (current) buffer."
   (let* ((prompt (buffer-substring-no-properties
                   (region-beginning) (region-end)))
          (gptel--system-message (or rewrite-message gptel--rewrite-message))
-         ;; always send context with system message
-         (gptel-use-context (and gptel-use-context 'system)))
+         (gptel-use-context (or
+			     ;; Never prepend context to last user prompt.
+			     (and (eq gptel-use-context 'user) 'system)
+			     gptel-use-context)))
     (deactivate-mark)
     (gptel-request prompt
       :context

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -464,7 +464,7 @@ Customize `gptel-directives' for task-specific prompts."
 
 gptel will include with the LLM request any additional context
 added with `gptel-add'.  This context can be ignored, included
-with the system message or included with the user prompt.
+with the system message or included with the last user prompt.
 
 Where in the request this context is included depends on the
 value of `gptel-use-context', set from here."
@@ -476,12 +476,12 @@ value of `gptel-use-context', set from here."
   :display-nil "No"
   :display-map '((nil    . "No")
                  (system . "with system message")
-                 (user   . "with user prompt"))
+                 (user   . "with last user prompt"))
   :key "-i"
   :reader (lambda (prompt &rest _)
-            (let* ((choices '(("No"                  . nil)
-                              ("with system message" . system)
-                              ("with user prompt"    . user)))
+            (let* ((choices '(("No"                    . nil)
+                              ("with system message"   . system)
+                              ("with last user prompt" . user)))
                    (destination (completing-read prompt choices nil t)))
               (cdr (assoc destination choices)))))
 

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -474,14 +474,16 @@ value of `gptel-use-context', set from here."
   :format " %k %d %v"
   :set-value #'gptel--set-with-scope
   :display-nil "No"
-  :display-map '((nil    . "No")
-                 (system . "with system message")
-                 (user   . "with last user prompt"))
+  :display-map '((nil            . "No")
+                 (system         . "Append to system message")
+                 (system-prepend . "Prepend to system message")
+                 (user           . "Prepend to last user prompt"))
   :key "-i"
   :reader (lambda (prompt &rest _)
-            (let* ((choices '(("No"                    . nil)
-                              ("with system message"   . system)
-                              ("with last user prompt" . user)))
+            (let* ((choices '(("No"                          . nil)
+                              ("Append to system message"    . system)
+                              ("Prepend to system message"   . system-prepend)
+                              ("Prepend to last user prompt" . user)))
                    (destination (completing-read prompt choices nil t)))
               (cdr (assoc destination choices)))))
 

--- a/gptel.el
+++ b/gptel.el
@@ -544,12 +544,12 @@ Currently supported options are:
 
     nil     - Do not use the context.
     system  - Include the context with the system message.
-    user    - Include the context with the user prompt."
+    user    - Include the context with the last user prompt."
   :group 'gptel
   :type '(choice
           (const :tag "Don't include context" nil)
           (const :tag "With system message" system)
-          (const :tag "With user prompt" user)))
+          (const :tag "With last user prompt" user)))
 
 (defvar-local gptel--old-header-line nil)
 
@@ -1161,7 +1161,7 @@ If the region is active limit the prompt to the region contents
 instead.
 
 If `gptel-context--alist' is non-nil and the additional
-context needs to be included with the user prompt, add it.
+context needs to be included with the last user prompt, add it.
 
 If PROMPT-END (a marker) is provided, end the prompt contents
 there."
@@ -1188,7 +1188,7 @@ there."
         (when (and gptel-context--alist
                    (eq gptel-use-context 'user)
                    (> (length prompts) 0))
-          (gptel--wrap-user-prompt gptel-backend prompts))
+          (gptel--wrap-last-user-prompt gptel-backend prompts))
         prompts))))
 
 (cl-defgeneric gptel--parse-buffer (backend max-entries)
@@ -1199,8 +1199,8 @@ BACKEND is the LLM backend in use.
 MAX-ENTRIES is the number of queries/responses to include for
 contexbt.")
 
-(cl-defgeneric gptel--wrap-user-prompt (backend _prompts)
-  "Wrap the last prompt in PROMPTS with gptel's context.
+(cl-defgeneric gptel--wrap-last-user-prompt (backend _prompts)
+  "Wrap the last user prompt in PROMPTS with gptel's context.
 
 PROMPTS is a structure as returned by `gptel--parse-buffer'.
 Typically this is a list of plists."

--- a/gptel.el
+++ b/gptel.el
@@ -542,14 +542,16 @@ included in the request.
 
 Currently supported options are:
 
-    nil     - Do not use the context.
-    system  - Include the context with the system message.
-    user    - Include the context with the last user prompt."
+    nil            - Do not use the context.
+    system         - Append the context to the system message.
+    system-prepend - Prepend the context to the system message.
+    user           - Prepend the context to the last user prompt."
   :group 'gptel
   :type '(choice
           (const :tag "Don't include context" nil)
-          (const :tag "With system message" system)
-          (const :tag "With last user prompt" user)))
+          (const :tag "Append to system message" system)
+          (const :tag "Prepend to system message" system-prepend)
+          (const :tag "Prepend to last user prompt" user)))
 
 (defvar-local gptel--old-header-line nil)
 
@@ -1010,7 +1012,8 @@ Model parameters can be let-bound around calls to this function."
   (let* ((gptel--system-message
           ;Add context chunks to system message if required
           (if (and gptel-context--alist
-                   (eq gptel-use-context 'system))
+                   (or (eq gptel-use-context 'system)
+                       (eq gptel-use-context 'system-prepend)))
               (gptel-context--wrap system)
             system))
          (gptel-stream stream)


### PR DESCRIPTION
... via new 'system-prepend'.

Certain use cases/LLMs may prefer to first see the context, then the system message.
