### PR TITLE
Update `gptel-model` docstring

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -413,19 +413,19 @@ call `gptel-send' with a prefix argument."
 (defcustom gptel-model 'gpt-4o-mini
   "GPT Model for chat.
 
-The name of the model as a string.  This is the name as expected
+The name of the model, as a symbol.  This is the name as expected
 by the LLM provider's API.
 
 The current options for ChatGPT are
-- \"gpt-3.5-turbo\"
-- \"gpt-3.5-turbo-16k\"
-- \"gpt-4o-mini\"
-- \"gpt-4\"
-- \"gpt-4o\"
-- \"gpt-4-turbo\"
-- \"gpt-4-turbo-preview\"
-- \"gpt-4-32k\"
-- \"gpt-4-1106-preview\"
+- `gpt-3.5-turbo'
+- `gpt-3.5-turbo-16k'
+- `gpt-4o-mini'
+- `gpt-4'
+- `gpt-4o'
+- `gpt-4-turbo'
+- `gpt-4-turbo-preview'
+- `gpt-4-32k'
+- `gpt-4-1106-preview'
 
 To set the model for a chat session interactively call
 `gptel-send' with a prefix argument."


### PR DESCRIPTION
I understand that `gptel-model` takes a symbol rather than a string now, so I believe the docstring should be updated to reflect this change.