### PR TITLE
Remove chatgpt-arcana from the list of alternatives

### DIFF
--- a/README.org
+++ b/README.org
@@ -1112,7 +1112,7 @@ Other Emacs clients for LLMs include
 - [[https://github.com/xenodium/chatgpt-shell][chatgpt-shell]]: comint-shell based interaction with ChatGPT.  Also supports DALL-E, executable code blocks in the responses, and more.
 - [[https://github.com/rksm/org-ai][org-ai]]: Interaction through special =#+begin_ai ... #+end_ai= Org-mode blocks.  Also supports DALL-E, querying ChatGPT with the contents of project files, and more.
 
-There are several more: [[https://github.com/CarlQLange/chatgpt-arcana.el][chatgpt-arcana]], [[https://github.com/MichaelBurge/leafy-mode][leafy-mode]], [[https://github.com/iwahbe/chat.el][chat.el]]
+There are several more: [[https://github.com/MichaelBurge/leafy-mode][leafy-mode]], [[https://github.com/iwahbe/chat.el][chat.el]]
 
 *** Packages using gptel
 


### PR DESCRIPTION
Since I have archived the chatgpt-arcana repo in favour of this one, there's no need to link to it!