### PR TITLE
gptel: Make `gptel-expert-commands` a user option

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -588,10 +588,12 @@ README for examples."
           (restricted-sexp :match-alternatives (gptel-backend-p 'nil)
 			   :tag "Other backend")))
 
-(defvar gptel-expert-commands nil
+(defcustom gptel-expert-commands nil
   "Whether experimental gptel options should be enabled.
 
-This opens up advanced options in `gptel-menu'.")
+This opens up advanced options in `gptel-menu'."
+  :safe #'always
+  :type 'boolean)
 
 (defvar-local gptel--bounds nil)
 (put 'gptel--bounds 'safe-local-variable #'always)


### PR DESCRIPTION
I noticed that `gptel-expert-commands` was not a user option after I defined it via `:custom` in use-package and it failed to be set. As far as I can tell, there is no reason for it to be a defvar, but if this was intentional feel free to reject this PR.