### PR TITLE
Support adding files in directories to context

### DIFF
--- a/README.org
+++ b/README.org
@@ -876,7 +876,7 @@ By default, gptel will query the LLM with the active region or the buffer conten
 
 You can include additional text regions, buffers or files with gptel's queries.  This additional context is "live" and not a snapshot.  Once added, the regions, buffers or files are scanned and included at the time of each query.  When using multi-modal models, added files can be of any supported type -- typically images.
 
-You can add a selected region, buffer or file to gptel's context from the menu, or call =gptel-add=.  (To add a file use =gptel-add= in Dired or use the dedicated =gptel-add-file= command.)
+You can add a selected region, buffer or file to gptel's context from the menu, or call =gptel-add=.  To add a file use =gptel-add= in Dired, or use the dedicated =gptel-add-file= command.  Directories will have their files added recursively after prompting for confirmation.
 
 You can examine the active context from the menu:
 #+html: <img src="https://github.com/karthink/gptel/assets/8607532/63cd7fc8-6b3e-42ae-b6ca-06ff935bae9c" align="center" alt="Image showing gptel's menu with the "inspect context" command.">

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -204,8 +204,7 @@ ACTION should be either `add' or `remove'."
                      (gptel-context--handle-binary file)
                    (gptel-context--add-text-file file)))
                 ('remove
-                 (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)
-                 (message "File \"%s\" removed from context." file)))))
+                 (gptel-context--remove-file file)))))
           files)))
 
 (defun gptel-context-add-file (path)
@@ -239,8 +238,7 @@ If CONTEXT is a directory, recursively removes all files in it."
    ((stringp context)                   ;file or directory
     (if (file-directory-p context)
         (gptel-context--handle-directory context 'remove)
-      (setf (alist-get context gptel-context--alist nil 'remove #'equal)
-            nil)))
+      (gptel-context--remove-file context)))
    ((region-active-p)
     (when-let ((contexts (gptel-context--in-region (current-buffer)
                                                    (region-beginning)
@@ -249,6 +247,12 @@ If CONTEXT is a directory, recursively removes all files in it."
    (t
     (when-let ((ctx (gptel-context--at-point)))
       (delete-overlay ctx)))))
+
+(defun gptel-context--remove-file (path)
+  "Remove the file at PATH from the gptel context."
+  (setf (alist-get path gptel-context--alist nil 'remove #'equal)
+	nil)
+  (message "File \"%s\" removed from context." path))
 
 (defun gptel-context--make-overlay (start end &optional advance)
   "Highlight the region from START to END.

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -206,8 +206,10 @@ ACTION should be either `add' or `remove'."
                      (gptel-context--add-binary-file file)
                    (gptel-context--add-text-file file)))
                 ('remove
-                 (gptel-context--remove-file file)))))
-          files)))
+                 (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)))))
+          files)
+    (when (eq action 'remove)
+      (message "Directory \"%s\" removed from context." path))))
 
 (defun gptel-context-add-file (path)
   "Add the file at PATH to the gptel context.
@@ -242,7 +244,8 @@ If CONTEXT is a directory, recursively removes all files in it."
    ((stringp context)                   ;file or directory
     (if (file-directory-p context)
         (gptel-context--add-directory context 'remove)
-      (gptel-context--remove-file context)))
+      (setf (alist-get context gptel-context--alist nil 'remove #'equal) nil)
+      (message "File \"%s\" removed from context." context)))
    ((region-active-p)
     (when-let ((contexts (gptel-context--in-region (current-buffer)
                                                    (region-beginning)
@@ -251,12 +254,6 @@ If CONTEXT is a directory, recursively removes all files in it."
    (t
     (when-let ((ctx (gptel-context--at-point)))
       (delete-overlay ctx)))))
-
-(defun gptel-context--remove-file (path)
-  "Remove the file at PATH from the gptel context."
-  (setf (alist-get path gptel-context--alist nil 'remove #'equal)
-	nil)
-  (message "File \"%s\" removed from context." path))
 
 (defun gptel-context--make-overlay (start end &optional advance)
   "Highlight the region from START to END.

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -112,14 +112,10 @@ context chunk.  This is accessible as, for example:
     (message "Current region added as context."))
    ;; If in dired
    ((derived-mode-p 'dired-mode)
-    (let ((files (cl-loop for file in (dired-get-marked-files)
-			  if (file-directory-p file)
-			  append (directory-files-recursively file "." t)
-			  else collect file)))
-      (mapc (if (and arg (< (prefix-numeric-value arg) 0))
-		#'gptel-context-remove
+    (mapc (if (and arg (< (prefix-numeric-value arg) 0))
+              #'gptel-context-remove
               #'gptel-context-add-file)
-            (cl-remove-if #'file-directory-p files))))
+          (dired-get-marked-files)))
    ;; If in an image buffer
    ((and (derived-mode-p 'image-mode)
          (gptel--model-capable-p 'media;)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -183,7 +183,7 @@ ACTION should be either `add' or `remove'."
   (let ((files (directory-files-recursively path "." t)))
     (mapc (lambda (file)
             (unless (file-directory-p file)
-              (pcase action
+              (pcase-exhaustive action
 		('add (gptel--file-binary-p file)
 		      (gptel-context--handle-binary file)
 		      (cl-pushnew (list file) gptel-context--alist :test #'equal)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -198,14 +198,14 @@ ACTION should be either `add' or `remove'."
 If PATH is a directory, recursively add all files in it.
 PATH should be readable as text."
   (interactive "fChoose file to add to context: ")
-  (if (file-directory-p path)
-      (gptel-context--handle-directory path 'add)
-    (if (gptel--file-binary-p path)
-        (gptel-context--handle-binary path)
-      ;; Add text file
-      (cl-pushnew (list path) gptel-context--alist :test #'equal)
-      (message "File \"%s\" added to context." path)
-      path)))
+  (cond ((file-directory-p path)
+	 (gptel-context--handle-directory path 'add))
+	((gptel--file-binary-p path)
+         (gptel-context--handle-binary path))
+	;; Add text file
+	((cl-pushnew (list path) gptel-context--alist :test #'equal)
+	 (message "File \"%s\" added to context." path)
+	 path)))
 
 ;;;###autoload (autoload 'gptel-add-file "gptel-context" "Add files to gptel's context." t)
 (defalias 'gptel-add-file #'gptel-context-add-file)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -91,10 +91,9 @@ context chunk.  This is accessible as, for example:
   context.  If there is already a gptel context at point, remove it
   instead.
 
-- If in Dired, add marked files or file at point to the context. If
-  the file at point is a directory, or directories are marked,
-  recursively add all their files. With negative prefix ARG, remove
-  them from the context instead.
+- If in Dired, add marked files or file at point to the context.
+  Directories will have all their files added recursively. With
+  negative prefix ARG, remove them from the context instead.
 
 - Otherwise add the current buffer to the context.  With positive
   prefix ARG, prompt for a buffer name and add it to the context.

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -184,10 +184,10 @@ ACTION should be either `add' or `remove'."
     (mapc (lambda (file)
             (unless (file-directory-p file)
               (pcase-exhaustive action
-		('add (gptel--file-binary-p file)
-		      (gptel-context--handle-binary file)
-		      (cl-pushnew (list file) gptel-context--alist :test #'equal)
-		      (message "File \"%s\" added to context." file))
+		('add (if (gptel--file-binary-p file)
+			  (gptel-context--handle-binary file)
+			(cl-pushnew (list file) gptel-context--alist :test #'equal)
+			(message "File \"%s\" added to context." file)))
 		('remove
 		 (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)
 		 (message "File \"%s\" removed from context." file)))))

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -91,11 +91,11 @@ context chunk.  This is accessible as, for example:
   context.  If there is already a gptel context at point, remove it
   instead.
 
-- If in Dired, add marked files or file at point to the context. With
-  negative prefix ARG, remove them from the context instead. If the
-  selection includes directories, add all their files recursively,
+- If in Dired, add marked files or file at point to the context. If
+  the selection includes directories, add all their files recursively,
   prompting the user for confirmation if called interactively or
-  CONFIRM is non-nil.
+  CONFIRM is non-nil. With negative prefix ARG, remove all files from
+  the context instead.
 
 - Otherwise add the current buffer to the context.  With positive
   prefix ARG, prompt for a buffer name and add it to the context.

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -173,6 +173,12 @@ context chunk.  This is accessible as, for example:
         (eq buffer-file-coding-system 'no-conversion))
     (file-missing (message "File \"%s\" is not readable." path))))
 
+(defun gptel-context--add-text-file (path)
+  "Add text file at PATH to context."
+  (cl-pushnew (list path) gptel-context--alist :test #'equal)
+  (message "File \"%s\" added to context." path)
+  path)
+
 (defun gptel-context--handle-binary (path)
   "Add binary file at PATH to context if supported.
 Return PATH if added, nil if ignored."
@@ -196,8 +202,7 @@ ACTION should be either `add' or `remove'."
                 ('add
                  (if (gptel--file-binary-p file)
                      (gptel-context--handle-binary file)
-                   (cl-pushnew (list file) gptel-context--alist :test #'equal)
-                   (message "File \"%s\" added to context." file)))
+                   (gptel-context--add-text-file file)))
                 ('remove
                  (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)
                  (message "File \"%s\" removed from context." file)))))
@@ -212,10 +217,7 @@ PATH should be readable as text."
 	 (gptel-context--handle-directory path 'add))
 	((gptel--file-binary-p path)
          (gptel-context--handle-binary path))
-	;; Add text file
-	((cl-pushnew (list path) gptel-context--alist :test #'equal)
-	 (message "File \"%s\" added to context." path)
-	 path)))
+	((gptel-context--add-text-file path))))
 
 ;;;###autoload (autoload 'gptel-add-file "gptel-context" "Add files to gptel's context." t)
 (defalias 'gptel-add-file #'gptel-context-add-file)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -179,7 +179,7 @@ context chunk.  This is accessible as, for example:
   (message "File \"%s\" added to context." path)
   path)
 
-(defun gptel-context--handle-binary (path)
+(defun gptel-context--add-binary-file (path)
   "Add binary file at PATH to context if supported.
 Return PATH if added, nil if ignored."
   (if-let* (((gptel--model-capable-p 'media))
@@ -192,7 +192,7 @@ Return PATH if added, nil if ignored."
     (message "Ignoring unsupported binary file \"%s\"." path)
     nil))
 
-(defun gptel-context--handle-directory (path action)
+(defun gptel-context--add-directory (path action)
   "Process all files in directory at PATH according to ACTION.
 ACTION should be either `add' or `remove'."
   (let ((files (directory-files-recursively path "." t)))
@@ -201,7 +201,7 @@ ACTION should be either `add' or `remove'."
               (pcase-exhaustive action
                 ('add
                  (if (gptel--file-binary-p file)
-                     (gptel-context--handle-binary file)
+                     (gptel-context--add-binary-file file)
                    (gptel-context--add-text-file file)))
                 ('remove
                  (gptel-context--remove-file file)))))
@@ -213,9 +213,9 @@ If PATH is a directory, recursively add all files in it.
 PATH should be readable as text."
   (interactive "fChoose file to add to context: ")
   (cond ((file-directory-p path)
-	 (gptel-context--handle-directory path 'add))
+	 (gptel-context--add-directory path 'add))
 	((gptel--file-binary-p path)
-         (gptel-context--handle-binary path))
+         (gptel-context--add-binary-file path))
 	((gptel-context--add-text-file path))))
 
 ;;;###autoload (autoload 'gptel-add-file "gptel-context" "Add files to gptel's context." t)
@@ -237,7 +237,7 @@ If CONTEXT is a directory, recursively removes all files in it."
       (setf (alist-get (current-buffer) gptel-context--alist nil 'remove) nil)))
    ((stringp context)                   ;file or directory
     (if (file-directory-p context)
-        (gptel-context--handle-directory context 'remove)
+        (gptel-context--add-directory context 'remove)
       (gptel-context--remove-file context)))
    ((region-active-p)
     (when-let ((contexts (gptel-context--in-region (current-buffer)

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -120,21 +120,19 @@ context chunk.  This is accessible as, for example:
 	   (action-fn (if remove-p
 			  #'gptel-context-remove
 			#'gptel-context-add-file)))
-      (when (or remove-p
-		(null dirs)
-		(null confirm)
+      (when (or remove-p (null dirs) (null confirm)
 		(y-or-n-p (format "Recursively add files from %d director%s? "
 				  (length dirs)
 				  (if (= (length dirs) 1) "y" "ies"))))
 	(mapc action-fn files))))
    ;; If in an image buffer
    ((and (derived-mode-p 'image-mode)
-         (gptel--model-capable-p 'media;)
+         (gptel--model-capable-p 'media)
          (buffer-file-name))
     (funcall (if (and arg (< (prefix-numeric-value arg) 0))
               #'gptel-context-remove
               #'gptel-context-add-file)
-          (buffer-file-name))))
+          (buffer-file-name)))
    ;; No region is selected, and ARG is positive.
    ((and arg (> (prefix-numeric-value arg) 0))
     (let* ((buffer-name (read-buffer "Choose buffer to add as context: " nil t))
@@ -145,9 +143,8 @@ context chunk.  This is accessible as, for example:
       (message "Buffer '%s' added as context." buffer-name)))
    ;; No region is selected, and ARG is negative.
    ((and arg (< (prefix-numeric-value arg) 0))
-    (when (or
-	   (null confirm)
-	   (y-or-n-p "Remove all contexts from this buffer? "))
+    (when (or (null confirm)
+	      (y-or-n-p "Remove all contexts from this buffer? "))
       (let ((removed-contexts 0))
         (cl-loop for cov in
                  (gptel-context--in-region (current-buffer) (point-min) (point-max))
@@ -214,6 +211,7 @@ ACTION should be either `add' or `remove'."
 
 (defun gptel-context-add-file (path)
   "Add the file at PATH to the gptel context.
+
 If PATH is a directory, recursively add all files in it.
 PATH should be readable as text."
   (interactive "fChoose file to add to context: ")
@@ -228,6 +226,7 @@ PATH should be readable as text."
 
 (defun gptel-context-remove (&optional context)
   "Remove the CONTEXT overlay from the contexts list.
+
 If CONTEXT is nil, removes the context at point.
 If selection is active, removes all contexts within selection.
 If CONTEXT is a directory, recursively removes all files in it."

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -184,13 +184,14 @@ ACTION should be either `add' or `remove'."
   (let ((files (directory-files-recursively path "." t)))
     (mapc (lambda (file)
             (unless (file-directory-p file)
-              (if (eq action 'add)
-                  (if (gptel--file-binary-p file)
-                      (gptel-context--handle-binary file)
-                    (cl-pushnew (list file) gptel-context--alist :test #'equal)
-                    (message "File \"%s\" added to context." file))
-                (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)
-                (message "File \"%s\" removed from context." file))))
+              (pcase action
+		('add (gptel--file-binary-p file)
+		      (gptel-context--handle-binary file)
+		      (cl-pushnew (list file) gptel-context--alist :test #'equal)
+		      (message "File \"%s\" added to context." file))
+		('remove
+		 (setf (alist-get file gptel-context--alist nil 'remove #'equal) nil)
+		 (message "File \"%s\" removed from context." file)))))
           files)))
 
 (defun gptel-context-add-file (path)


### PR DESCRIPTION
Currently, attempting to add directories to the context in Dired will throw an error. This PR provides support for adding files in directories to the context: if there is a directory at point, or the marked files include one or more directories, their files will recursively be added to the context.