### PR TITLE
gptel-curl: don't try converting CR-LF on Windows

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -113,6 +113,10 @@ the response is inserted into the current buffer after point."
          (backend (buffer-local-value 'gptel-backend (plist-get info :buffer)))
          (process (apply #'start-process "gptel-curl"
                          (generate-new-buffer "*gptel-curl*") "curl" args)))
+    (when (memq system-type '(windows-nt ms-dos))
+      ;; Don't try to convert cr-lf to cr on Windows so that curl's "header size
+      ;; in bytes" stays correct
+      (set-process-coding-system process 'utf-8-unix 'utf-8-unix))
     (when (eq gptel-log-level 'debug)
       (gptel--log (mapconcat #'shell-quote-argument (cons "curl" args) " \\\n")
                   "request Curl command" 'no-json))


### PR DESCRIPTION
We use curl's header size output to `goto-char` to the end of the response header (to parse the JSON that starts there).

On Windows, however, processes we launch will typically output Windows-style line endings, with CR-LF; by default, Emacs tries to convert this to just CR, to avoid seeing ugly `^M` characters at the end of lines.

 `curl` dumps what it gets from the server directly... but HTTP also specifies
 CR-LF line endings, at least at the end of headers. On Windows, Emacs converts
 these to CRs, removing the LFs, and thus causing our header size measurement to
 be slightly off (the buffer now includes fewer characters of header vs. what
 `curl` told us we'd have). So `goto-char` seeks too much ahead, missing the
 beginning of the JSON; we get a JSON parse error.

This PR fixes this by forcing the process coding system to the UNIX variant (with no CR-LF conversion).

We gate this behind an "is this Windows" check so it shouldn't affect other systems.

Fixes https://github.com/karthink/gptel/issues/455.