### PR TITLE
bug fix in Ollama backend: options-plist -> prompts-plit

### DIFF
--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -82,13 +82,11 @@ Intended for internal use only.")
                          (gptel-backend-stream gptel-backend))
                      :json-false))))
     (when gptel-temperature
-      (setq options-plist
-            (plist-put options-plist :temperature
-                       gptel-temperature)))
+      (plist-put prompts-plist :temperature
+                 gptel-temperature))
     (when gptel-max-tokens
-      (setq options-plist
-            (plist-put options-plist :num_predict
-                       gptel-max-tokens)))
+      (plist-put prompts-plist :num_predict
+                 gptel-max-tokens))
     ;; Merge request params with model and backend params.
     (gptel--merge-plists
      prompts-plist


### PR DESCRIPTION
hey thanks for working on this package, it's amazing 💜

latest commit introduced a small bug in `gptel-ollama.el`: code was trying to modify `options-plist` without having setting it, resulting in "setq: Symbol’s value as variable is void: options-plist". 

Here's my fix: if I'm understanding things right, `options-plist` is not used anymore, so we just put the values directly into `prompts-plist`