### PR TITLE
Add windows platform check for the curl file size thresh

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -255,7 +255,9 @@ Adjusting this value may be necessary depending on the environment
 and the typical size of the data being sent in GPTel queries.
 A larger value may improve performance by avoiding the overhead of creating
 temporary files for small data payloads, while a smaller value may be needed
-if the command-line argument size is limited by the operating system."
+if the command-line argument size is limited by the operating system.
+The default for windows comes from Microsoft documentation located here:
+https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa"
   :type 'natnum)
 
 (defcustom gptel-response-filter-functions

--- a/gptel.el
+++ b/gptel.el
@@ -256,6 +256,7 @@ and the typical size of the data being sent in GPTel queries.
 A larger value may improve performance by avoiding the overhead of creating
 temporary files for small data payloads, while a smaller value may be needed
 if the command-line argument size is limited by the operating system.
+
 The default for windows comes from Microsoft documentation located here:
 https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa"
   :type 'natnum)


### PR DESCRIPTION
This makes sure that windows doesn't bark at you when you pass arguments to the curl subprocess over window's limit of 32767.

closes #517