### PR TITLE
Remove fallback value for `gptel--system-message`

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -1017,8 +1017,7 @@ MODE-SYM is typically a major-mode symbol."
 
 
 (defvar gptel--system-message
-  (or (alist-get 'default gptel-directives)
-      "You are a large language model living in Emacs and a helpful assistant. Respond concisely.")
+  (alist-get 'default gptel-directives)
   "The system message used by gptel.")
 (put 'gptel--system-message 'safe-local-variable #'always)
 


### PR DESCRIPTION
The fallback message "You are a large language model..." is no longer
needed since the default value of `gptel-directives` can be `nil`.