### PR TITLE
Add support for OpenAI o1 model

### DIFF
--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -154,7 +154,7 @@ with differing settings.")
     (when gptel-max-tokens
       ;; HACK: The OpenAI API has deprecated max_tokens, but we still need it
       ;; for OpenAI-compatible APIs like GPT4All (#485)
-      (plist-put prompts-plist (if (memq gptel-model '(o1-preview o1-mini))
+      (plist-put prompts-plist (if (memq gptel-model '(o1 o1-preview o1-mini))
                                    :max_completion_tokens :max_tokens)
                  gptel-max-tokens))
     ;; Merge request params with model and backend params.

--- a/gptel.el
+++ b/gptel.el
@@ -545,8 +545,16 @@ To set the temperature for a chat session interactively call
      :input-cost 10
      :output-cost 30
      :cutoff-date "2023-12")
-    (o1-preview
+    (o1
      :description "Reasoning model designed to solve hard problems across domains"
+     :context-window 200
+     :input-cost 15
+     :output-cost 60
+     :cutoff-date "2023-10"
+     :capabilities (nosystem)
+     :request-params (:stream :json-false))
+    (o1-preview
+     :description "DEPRECATED: PLEASE USE o1"
      :context-window 128
      :input-cost 15
      :output-cost 60


### PR DESCRIPTION
o1 has superceded o1-preview, the costs are the same, o1 is either identical or better than o1-preview