### PR TITLE
Improve robustness: `gptel-org--link-standalone-p`

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -291,10 +291,10 @@ for inclusion into the user prompt for the gptel request."
   (when-let* ((par (org-element-lineage object '(paragraph))))
     (and (= (gptel-org--element-begin object)
             (save-excursion
-              (goto-char (and par (org-element-property :contents-begin par)))
+              (goto-char (org-element-property :contents-begin par))
               (skip-chars-forward "\t ")
               (point)))                 ;account for leading space before object
-         (<= (- (and par (org-element-property :contents-end par))
+         (<= (- (org-element-property :contents-end par)
                 (org-element-property :end object))
              1))))
 

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -294,7 +294,8 @@ for inclusion into the user prompt for the gptel request."
               (goto-char (and par (org-element-property :contents-begin par)))
               (skip-chars-forward "\t ")
               (point)))                 ;account for leading space
-         (<= (- (and par (org-element-property :contents-end par))(org-element-property :end object))
+         (<= (- (and par (org-element-property :contents-end par))
+                (org-element-property :end object))
              1))))
 
 (defun gptel-org--send-with-props (send-fun &rest args)

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -287,17 +287,17 @@ for inclusion into the user prompt for the gptel request."
 
 (defun gptel-org--link-standalone-p (object)
   "Check if link OBJECT is on a line by itself."
-  ;; Specify ancestor TYPES as list (#245)
-  (let ((par (org-element-lineage object '(paragraph))))
-    (and (= (gptel-org--element-begin object)
-            (save-excursion
-              (goto-char (org-element-property :contents-begin par))
-              (skip-chars-forward "\t ")
-              (point)))                 ;account for leading space
-                                        ;before object
-         (<= (- (org-element-property :contents-end par)
-                (org-element-property :end object))
-             1))))
+  (let* ((par (org-element-lineage object '(paragraph)))
+         (begin (and par (org-element-property :contents-begin par)))
+         (end (and par (org-element-property :contents-end par))))
+    (when (and begin end)
+      (and (= (gptel-org--element-begin object)
+              (save-excursion
+                (goto-char begin)
+                (skip-chars-forward "\t ")
+                (point)))
+           (<= (- end (org-element-property :end object))
+               1)))))
 
 (defun gptel-org--send-with-props (send-fun &rest args)
   "Conditionally modify SEND-FUN's calling environment.

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -287,17 +287,15 @@ for inclusion into the user prompt for the gptel request."
 
 (defun gptel-org--link-standalone-p (object)
   "Check if link OBJECT is on a line by itself."
-  (let* ((par (org-element-lineage object '(paragraph)))
-         (begin (and par (org-element-property :contents-begin par)))
-         (end (and par (org-element-property :contents-end par))))
-    (when (and begin end)
-      (and (= (gptel-org--element-begin object)
-              (save-excursion
-                (goto-char begin)
-                (skip-chars-forward "\t ")
-                (point)))
-           (<= (- end (org-element-property :end object))
-               1)))))
+  ;; Specify ancestor TYPES as list (#245)
+  (when-let* ((par (org-element-lineage object '(paragraph))))
+    (and (= (gptel-org--element-begin object)
+            (save-excursion
+              (goto-char (and par (org-element-property :contents-begin par)))
+              (skip-chars-forward "\t ")
+              (point)))                 ;account for leading space
+         (<= (- (and par (org-element-property :contents-end par))(org-element-property :end object))
+             1))))
 
 (defun gptel-org--send-with-props (send-fun &rest args)
   "Conditionally modify SEND-FUN's calling environment.

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -293,7 +293,7 @@ for inclusion into the user prompt for the gptel request."
             (save-excursion
               (goto-char (and par (org-element-property :contents-begin par)))
               (skip-chars-forward "\t ")
-              (point)))                 ;account for leading space
+              (point)))                 ;account for leading space before object
          (<= (- (and par (org-element-property :contents-end par))
                 (org-element-property :end object))
              1))))


### PR DESCRIPTION
- Added checks to ensure paragraph (`par`) is valid before accessing its
- properties.  Safeguarded against `nil` values for `:contents-begin`
- and `:contents-end` properties.  Ensured the function proceeds only if
- all necessary properties are non-nil.

These changes prevent errors when element properties are unexpectedly `nil`, like when trying to send this, with one or more characters between the brackets

\#+begin_src
[[ ]]
\#+end_src

closes https://github.com/karthink/gptel/issues/593