### PR TITLE
Pass nil results through to model

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -1931,10 +1931,9 @@ Run post-response hooks."
                   (arg-values)
                   (process-tool-result
                    (lambda (result)
-                     (when result
-                       (plist-put info :tool-success t)
-                       (plist-put tool-call :result (gptel--to-string result))
-                       (push (list name arg-values result) result-alist))
+                     (plist-put info :tool-success t)
+                     (plist-put tool-call :result (gptel--to-string result))
+                     (push (list name arg-values result) result-alist)
                      (cl-incf tool-idx)
                      (when (>= tool-idx ntools) ; All tools have run
                        (gptel--inject-prompt


### PR DESCRIPTION
When the tool call succeeds (as in does not error) but returns nil, we still need to show the model that the tool returned a nil result.

Otherwise the model seems to not progress in its reply.

`gptel--to-string` handles this fine and the model happily reported observing the "nil" result.