### PR TITLE
Parameters Required

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -1567,8 +1567,10 @@ implementation, used by OpenAI-compatible APIs and Ollama."
                              ,@(if enum (list :enum (vconcat enum)))
                              ,@(cond
                                 ((equal type "object")
-                                  :additionalProperties :json-false))
                                  (list :properties (plist-get arg :properties)
+                                       :required (or (plist-get arg :required)
+                                                     (vector))
+                                       :additionalProperties :json-false))
                                 ((equal type "array")
                                  ;; TODO(tool) If the item type is an object,
                                  ;; add :additionalProperties to it

--- a/gptel.el
+++ b/gptel.el
@@ -1567,8 +1567,8 @@ implementation, used by OpenAI-compatible APIs and Ollama."
                              ,@(if enum (list :enum (vconcat enum)))
                              ,@(cond
                                 ((equal type "object")
-                                 (list :parameters (plist-get arg :parameters)
                                   :additionalProperties :json-false))
+                                 (list :properties (plist-get arg :properties)
                                 ((equal type "array")
                                  ;; TODO(tool) If the item type is an object,
                                  ;; add :additionalProperties to it


### PR DESCRIPTION
```
:TOOL_CALL:
(all_arg_types (:foo 42))

object: (:foo 42)
```
:boom: 

:shipit: 

Related tool example found [here](https://github.com/karthink/gptel/issues/514#issuecomment-2627491244)

I found this by inspecting the tool use and noticing a `:parameters nil` in the plist describing the tool to the backend.  The object spec wasn't being given to the backend at all.