### PR TITLE
gptel-transient: allow generating output directly to the *scratch* buffer

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -510,6 +510,7 @@ Also format its value in the Transient menu."
      :reader
      (lambda (prompt _ _history)
        (read-buffer prompt (buffer-name (other-buffer)) nil)))
+	("t" "*scratch* buffer" "t")
     ("k" "Kill-ring" "k")]]
   [["Send"
     (gptel--suffix-send)
@@ -1184,6 +1185,13 @@ This sets the variable `gptel-include-tool-results', which see."
                      args))
       (setq output-to-other-buffer-p t)
       (setq buffer (get-buffer-create gptel-buffer-name))
+      (with-current-buffer buffer (setq position (point))))
+	 ((setq gptel-buffer-name
+            (cl-some (lambda (s) (and (stringp s) (string-prefix-p "t" s)
+									  (substring s 1)))
+                     args))
+      (setq output-to-other-buffer-p t)
+      (setq buffer (get-buffer-create "*scratch*"))
       (with-current-buffer buffer (setq position (point)))))
 
     (prog1 (gptel-request prompt


### PR DESCRIPTION
I use the `*scratch*` buffer extensively when working with text and code, and I find it very useful to redirect the output from gptel directly to `*scratch*`. I've been maintaining my own branch for a while, but perhaps others would find this useful, too?
