### PR TITLE
Update details for openai o models

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -586,7 +586,7 @@ To set the temperature for a chat session interactively call
      :input-cost 3
      :output-cost 12
      :cutoff-date "2023-10"
-     :capabilities (nosystem reasoning)
+     :capabilities (structured-outputs tool-use json url function-calling developer-message)
      :request-params (:developer :reasoning_effort))
     ;; limited information available
     (gpt-4-32k

--- a/gptel.el
+++ b/gptel.el
@@ -574,7 +574,7 @@ To set the temperature for a chat session interactively call
      :cutoff-date "2023-10"
      :capabilities (nosystem reasoning))
     (o1-mini
-     :description "Faster and cheaper reasoning model good at coding, math, and science"
+     :description "DEPRECATED: PLEASE USE o3-mini"
      :context-window 128
      :input-cost 3
      :output-cost 12

--- a/gptel.el
+++ b/gptel.el
@@ -563,8 +563,7 @@ To set the temperature for a chat session interactively call
      :context-window 200
      :input-cost 15
      :output-cost 60
-     :cutoff-date "2023-10"
-     :request-params (:stream :json-false))
+     :cutoff-date "2023-10")
     (o1-preview
      :description "DEPRECATED: PLEASE USE o1"
      :capabilities (nosystem media)
@@ -573,16 +572,14 @@ To set the temperature for a chat session interactively call
      :input-cost 15
      :output-cost 60
      :cutoff-date "2023-10"
-     :capabilities (nosystem reasoning)
-     :request-params (:stream :json-false))
+     :capabilities (nosystem reasoning))
     (o1-mini
      :description "Faster and cheaper reasoning model good at coding, math, and science"
      :context-window 128
      :input-cost 3
      :output-cost 12
      :cutoff-date "2023-10"
-     :capabilities (nosystem reasoning)
-     :request-params (:stream :json-false))
+     :capabilities (nosystem reasoning))
     (o3-mini
      :description "High intelligence at the same cost and latency targets of o1-mini"
      :context-window 200
@@ -590,7 +587,7 @@ To set the temperature for a chat session interactively call
      :output-cost 12
      :cutoff-date "2023-10"
      :capabilities (nosystem reasoning)
-     :request-params (:stream :json-false))
+     :request-params (:developer :reasoning_effort))
     ;; limited information available
     (gpt-4-32k
      :capabilities (tool-use)

--- a/gptel.el
+++ b/gptel.el
@@ -586,7 +586,7 @@ To set the temperature for a chat session interactively call
      :input-cost 3
      :output-cost 12
      :cutoff-date "2023-10"
-     :capabilities (structured-outputs tool-use json url function-calling developer-message)
+     :capabilities (nosystem structured-outputs json url function-calling developer-message)
      :request-params (:developer :reasoning_effort))
     ;; limited information available
     (gpt-4-32k


### PR DESCRIPTION
From the docs https://platform.openai.com/docs/models#o3-mini

> o3-mini is our most recent small reasoning model, providing high
> intelligence **at the same cost and latency targets of o1-mini.** o3-mini
> also supports key developer features, like Structured Outputs, function
> calling, Batch API, and more. Like other models in the o-series, it is
> designed to excel at science, math, and coding tasks.

> The o1 reasoning model is designed to solve hard problems across
> domains. o1-mini is a faster and more affordable reasoning model, but we
> **recommend using the newer o3-mini model** that features higher
> intelligence at the **same latency and price as o1-mini.**