### PR TITLE
gptel-transient: Improve directive/system message editing

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1364,7 +1364,8 @@ it is run after exiting the edit."
           ;; If it's a list, insert only the system message part
           (insert (car-safe (gptel--parse-directive directive 'raw)))
           (push-mark nil 'nomsg))
-        (activate-mark))
+        (activate-mark)
+	(visual-line-mode 1))
       (display-buffer (current-buffer)
                       `((display-buffer-below-selected)
                         (body-function . ,#'select-window)


### PR DESCRIPTION
I find no value in activating the directive in the edit buffer as region, and it can be quite annoying.

Additionally, since the directives and system messages are primarily regular text, enabling visual-line-mode (word wrapping) seems logical.