### PR TITLE
gptel-transient: ensure point is after prompt

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -172,7 +172,8 @@ will toggle its visibility state."
           (_ (overlay-put ov 'gptel 'partial)
              (funcall update ov (truncate-string-to-width
                                  prefix max-width nil nil
-                                 'ellipsis))))))))
+                                 'ellipsis)))))
+      (goto-char (point-max)))))
 
 (defun gptel--transient-read-variable (prompt initial-input history)
   "Read value from minibuffer and interpret the result as a Lisp object.


### PR DESCRIPTION
Basically, this code changes this:
![image](https://github.com/user-attachments/assets/64692e37-b482-40bd-b66b-b632ac547892)
to:
![image](https://github.com/user-attachments/assets/19aa845d-3c47-4fe4-a64d-a5dcba11e13f)
