### PR TITLE
Fix read-only behaviour in gptel--edit-directive

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1361,10 +1361,8 @@ setting up the buffer."
               "# Example: You are a poet. Reply only in verse."))
          "\n\n")
         (add-text-properties
-         (point-min) (1- (point))
-         (list 'read-only t 'face 'font-lock-comment-face))
-        ;; TODO: make-separator-line requires Emacs 28.1+.
-        ;; (insert (propertize (make-separator-line) 'rear-nonsticky t))
+         (point-min) (point)
+         (list 'read-only t 'face 'font-lock-comment-face 'front-sticky t 'rear-nonsticky t))
         (set-marker msg-start (point))
         (save-excursion
           ;; If it's a list, insert only the system message part


### PR DESCRIPTION
* gptel-transient.el (gptel--edit-directive): `make-separator-line' is a function introduced in Emacs 28.1, so it was disabled with a comment.  However, we require compat-29.1.4.1 making the function available in Emacs ~~28~~ EDIT: 27, and it is already used in other places, so enable it here as well.  Drop the extra newline from the examples above.