### PR TITLE
gptel-transient: Improve "Scope" infix appearence

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -761,9 +761,9 @@ value of `gptel-use-context', set from here."
   :argument "scope"
   :variable 'gptel--set-buffer-locally
   :class 'gptel--scope
-  :format "  %k %d %v"
+  :format " %k %d %v"
   :key "="
-  :description (propertize "Scope" 'face 'transient-inactive-argument))
+  :description "Scope")
 
 (transient-define-infix gptel--infix-num-messages-to-send ()
   "Number of recent messages to send with each exchange.


### PR DESCRIPTION
* gptel-transient (gptel--infix-variable-scope): Drop extra space from :format and `transient-inactive-argument' face.

(Unless there is some reason to have the word "Scope" greyed out... but how is it "inactive"?)
