### PR TITLE
gptel: Improve major mode name handling

### DIFF
--- a/gptel-context.el
+++ b/gptel-context.el
@@ -361,7 +361,7 @@ START and END signify the region delimiters."
     (let ((is-top-snippet t)
           (previous-line 1))
       (insert (format "In buffer `%s`:" (buffer-name buffer))
-              "\n\n```" (gptel--strip-mode-suffix (buffer-local-value
+              "\n\n```" (gptel--pretty-mode-name (buffer-local-value
                                                    'major-mode buffer))
               "\n")
       (dolist (context contexts)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -147,9 +147,9 @@ which see."
   (or (save-mark-and-excursion
         (run-hook-with-args-until-success
          'gptel-rewrite-directives-hook))
-      (let* ((lang (downcase (gptel--strip-mode-suffix major-mode)))
-             (article (if (and lang (not (string-empty-p lang))
-                               (memq (aref lang 0) '(?a ?e ?i ?o ?u)))
+      (let* ((lang (gptel--pretty-mode-name major-mode))
+	     (article (if (and lang (not (string-empty-p lang))
+                               (memq (aref (downcase lang) 0) '(?a ?e ?i ?o ?u)))
                           "an" "a")))
         (if (derived-mode-p 'prog-mode)
             (format (concat "You are %s %s programmer.  "

--- a/gptel.el
+++ b/gptel.el
@@ -1007,32 +1007,26 @@ FILE is assumed to exist and be a regular file."
   "Check if gptel response at position PT has variants."
   (get-char-property (or pt (point)) 'gptel-history))
 
-(defvar gptel--mode-description-alist
-  '((js2-mode      . "Javascript")
-    (sh-mode       . "Shell")
-    (enh-ruby-mode . "Ruby")
-    (yaml-mode     . "Yaml")
-    (yaml-ts-mode  . "Yaml")
-    (rustic-mode   . "Rust"))
+(defvar gptel--pretty-mode-name-alist
+  '((js2-mode        . "JavaScript")
+    (emacs-lisp-mode . "Emacs Lisp")
+    (cperl-mode      . "Perl")
+    (sh-mode         . "Shell")
+    (enh-ruby-mode   . "Ruby")
+    (rustic-mode     . "Rust"))
   "Mapping from unconventionally named major modes to languages.
 
 This is used when generating system prompts for rewriting and
 when including context from these major modes.")
 
-(defun gptel--strip-mode-suffix (mode-sym)
-  "Remove the -mode suffix from MODE-SYM.
-
-MODE-SYM is typically a major-mode symbol."
+(defun gptel--pretty-mode-name (mode-sym)
+  "Return pretty name of major mode MODE-SYM."
   (or (alist-get mode-sym gptel--mode-description-alist)
-      (let ((mode-name (thread-last
-                         (symbol-name mode-sym)
-                         (string-remove-suffix "-mode")
-                         (string-remove-suffix "-ts"))))
-        ;; NOTE: The advertised calling convention of provided-mode-derived-p
-        ;; has changed in Emacs 30, this needs to be updated eventually
-        (if (provided-mode-derived-p
-             mode-sym 'prog-mode 'text-mode 'tex-mode)
-            mode-name ""))))
+      (with-temp-buffer
+	(when (fboundp mode-sym)
+	  (funcall mode-sym)
+	  (car (split-string (substring-no-properties  ; drop suffixes like /*l
+			      (format-mode-line (list mode-name))) "/"))))))
 
 ;;;; Directive handling
 


### PR DESCRIPTION
* gptel.el: (gptel--mode-description-alist, gptel--pretty-mode-name-alist): Rename alist.  Add emacs-lisp-mode ("ELisp" is not as clear).  Add cperl-mode.  Drop Yaml-mode. (gptel--strip-mode-suffix, gptel--pretty-mode-name): Replace function with new implementation with more meaningful name.  It uses the pretty name already provided by the major-mode, which typically starts with capital letter.  Using mode-name alone is not robust since it's not always a string.

* gptel-rewrite.el (gptel--rewrite-directive-default): Call the new function.  Don't downcase it.

* gptel-context.el (gptel-context--insert-buffer-string): Call the new function.