### PR TITLE
gptel-transient: Fix face related bug

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -550,7 +550,7 @@ Also format its value in the Transient menu."
     (gptel--infix-add-directive)]
    [:pad-keys t ""
     (:info #'gptel--describe-infix-context
-     :face 'transient-heading :format "%d")
+     :face transient-heading :format "%d")
     (gptel--infix-context-add-region)
     (gptel--infix-context-add-buffer)
     (gptel--infix-context-add-file)


### PR DESCRIPTION
* gptel-transient (gptel-menu): Fix a slight bug introduced in commit edf834a ("Provide description of send action") where an extra quote (') caused error "Invalid face reference: quote" to appear in *Messages* and the "Context" heading to have incorrect face (color).