### PR TITLE
Add a --noproxy option to gptel-curl--get-args

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -86,10 +86,13 @@ REQUEST-DATA is the data to send, TOKEN is a unique identifier."
          (add-hook 'gptel-post-response-functions cleanup-fn)
          (list "--data-binary"
                (format "@%s" temp-filename))))
-     (when (not (string-empty-p gptel-proxy))
-       (list "--proxy" gptel-proxy
-             "--proxy-negotiate"
-             "--proxy-user" ":"))
+     (when (or (not (string-empty-p gptel-proxy)) gptel-noproxy)
+       (append
+        (when gptel-proxy
+          (list "--proxy" gptel-proxy))
+        (when gptel-noproxy
+          (list "--noproxy" gptel-noproxy))
+        (list "--proxy-negotiate" "--proxy-user" ":")))
      (cl-loop for (key . val) in headers
               collect (format "-H%s: %s" key val))
      (list url))))

--- a/gptel.el
+++ b/gptel.el
@@ -215,6 +215,14 @@ Passed to curl via --proxy arg, for example \"proxy.yourorg.com:80\"
 Leave it empty if you don't use a proxy."
   :type 'string)
 
+(defcustom gptel-noproxy nil
+  "How to handle --noproxy argument in curl requests.
+When nil, don't pass --noproxy argument.
+When a string, pass that string as --noproxy value.
+Use this to override noproxy variables set elsewhere in Emacs."
+  :type '(choice (const :tag "Don't set noproxy" nil)
+          (string :tag "Set specific noproxy value")))
+
 (defcustom gptel-api-key #'gptel-api-key-from-auth-source
   "An API key (string) for the default LLM backend.
 


### PR DESCRIPTION
This adds a --noproxy option to the call to curl in gptel-curl--get-args, along with a variable to configure that option.

In an development environment I use, I need to set the noproxy environment variable in emacs to get various features to work, but to communicate with an LLM endpoint I need to call curl with a conflicting noproxy variable. This provides a convenient way to manage this.