### PR TITLE
Store some strings in variables in gptel-rewrite.el

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -29,6 +29,10 @@
 (defvar eldoc-documentation-functions)
 (defvar diff-entire-buffers)
 
+(defvar gptel-rewrite--assistant-instruction-question
+  "What is the required change?")
+(defvar gptel-rewrite--default-rewrite-prefix "Rewrite: ")
+
 (declare-function diff-no-select "diff")
 (declare-function rmc--add-key-description "rmc")
 
@@ -534,7 +538,7 @@ By default, gptel uses the directive associated with the `rewrite'
   (unless (or gptel--rewrite-overlays (use-region-p))
     (user-error "`gptel-rewrite' requires an active region or rewrite in progress."))
   (unless gptel--rewrite-message
-    (setq gptel--rewrite-message "Rewrite: "))
+    (setq gptel--rewrite-message gptel-rewrite--default-rewrite-prefix))
   (transient-setup 'gptel-rewrite))
 
 ;; * Transient infixes for rewriting
@@ -576,7 +580,7 @@ By default, gptel uses the directive associated with the `rewrite'
                                           minibuffer-local-map)))
               (minibuffer-with-setup-hook cycle-prefix
                 (read-string
-                 prompt (or gptel--rewrite-message "Rewrite: ")
+                 prompt (or gptel--rewrite-message gptel-rewrite--default-rewrite-prefix)
                  history)))))
 
 (transient-define-argument gptel--infix-rewrite-diff:-U ()
@@ -616,7 +620,7 @@ generated from functions."
           (and gptel-use-context (if nosystem 'user 'system)))
          (prompt (list (or (get-char-property (point) 'gptel-rewrite)
                            (buffer-substring-no-properties (region-beginning) (region-end)))
-                       "What is the required change?"
+                       gptel-rewrite--assistant-instruction-question
                        (or rewrite-message gptel--rewrite-message))))
     (when nosystem
       (setcar prompt (concat (car-safe (gptel--parse-directive


### PR DESCRIPTION
Hi, thanks for creating this great package.

I've been exploring `gptel-rewrite`, and I primarily use language models in Finnish. I noticed that each rewrite request includes the prompt string "What is the required change?". This may cause issues, particularly with Google's Gemini, which sometimes identifies itself as an English model and declines to process Finnish text. To address this, I've modified the code to make this string configurable. Additionally, I've made the "Rewrite: " string configurable as well, as I find it useful to customize. I'm willing to contribute these changes, so please let me know what adjustments are needed for them to be accepted.  I feel the change is necessary to support non-english use cases.

