### PR TITLE
* gptel-curl: Require gptel-org when needed for org transform (#694)

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -137,6 +137,7 @@ the response is inserted into the current buffer after point."
                            (when (with-current-buffer (plist-get info :buffer)
                                    (and (derived-mode-p 'org-mode)
                                         gptel-org-convert-response))
+			     (require 'gptel-org)
                              (gptel--stream-convert-markdown->org
                               (plist-get info :position))))
                      (unless (plist-get info :callback)

--- a/gptel.el
+++ b/gptel.el
@@ -2743,6 +2743,7 @@ the response is inserted into the current buffer after point."
     (when (with-current-buffer (plist-get info :buffer)
             (and (derived-mode-p 'org-mode)
                  gptel-org-convert-response))
+      (require 'gptel-org)
       (plist-put info :transformer #'gptel--convert-markdown->org))
     (plist-put info :callback callback)
     (when gptel-log-level               ;logging


### PR DESCRIPTION
FIxes #694 by requiring gptel-org when needed for  gptel--stream-convert-markdown->org'.
