### PR TITLE
elpaignore: Add .github

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,1 +1,3 @@
 test
+.github
+.elpaigore


### PR DESCRIPTION
Just some minor finishing touch before 0.9.8 release to elpa.nongu.org. 

MELPA does not include documentation (`README.org`, `NEWS`, `LICENSE`) by default, unlike (non-)GNUELPA.  But IMHO they are useful (and not litter, like `.github/ISSUE_TEMPLATE`)  and consume tiny amount of disk space, so I don't see a reason to exclude them.