### PR TITLE
dir-locals: Set some project specific local variables

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil . ((indent-tabs-mode . nil)
+	 (sentence-end-double-space . t)
+	 (bug-reference-url-format . "https://github.com/karthink/gptel/issues/%s"))))


### PR DESCRIPTION
.dir-locals.el: Set `indent-tabs-mode` to nil to avoid whitespace problems (particularly with `aggressive-indent-mode`), as the project predominantly uses spaces for indentation.  Ensure sentences end with double spaces to adhere to the house style.  Point `bug-reference-url-format` to Github issues; while there are few bug references in the codebase, this may be useful later.