### PR TITLE
README: Restructure authinfo explanation

### DIFF
--- a/README.org
+++ b/README.org
@@ -89,8 +89,8 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
       - [[#spacemacs][Spacemacs]]
   - [[#setup][Setup]]
     - [[#chatgpt][ChatGPT]]
-    - [[#configuring-other-llm-backends][Configuring other LLM backends]]
     - [[#other-llm-backends][Other LLM backends]]
+      - [[#optional-securing-api-keys-with-authinfo][(Optional) Securing API keys with =authinfo=]]
       - [[#azure][Azure]]
       - [[#gpt4all][GPT4All]]
       - [[#ollama][Ollama]]
@@ -199,24 +199,28 @@ Procure an [[https://platform.openai.com/account/api-keys][OpenAI API key]].
 Optional: Set =gptel-api-key= to the key. Alternatively, you may choose a more secure method such as:
 
 - Setting it to a custom function that returns the key.
-- Leaving it set to the default =gptel-api-key-from-auth-source= function which reads keys from =~/.authinfo=.
+- Leaving it set to the default =gptel-api-key-from-auth-source= function which reads keys from =~/.authinfo=. (See [[#optional-securing-api-keys-with-authinfo][authinfo details]])
 
-*** Configuring other LLM backends
-ChatGPT is the default LLM backend for gptel, if you want to use other LLM backends (like Claude/Anthropic) you need to register and configure them first.
+*** Other LLM backends
 
-Add your API keys to =~/.authinfo=, and leave =gptel-api-key= set to its default. By default, the API endpoint DNS name (e.g. "api.openai.com") is used as HOST and "apikey" as USER.
+ChatGPT is configured out of the box.  If you want to use other LLM backends (like Ollama, Claude/Anthropic or Gemini) you need to register and configure them first.
+
+As an example, registering a backend typically looks like the following:
+#+begin_src emacs-lisp
+(gptel-make-anthropic "Claude" :stream t :key gptel-api-key)
+#+end_src
+Once this backend is registered, you'll see model names prefixed by "Claude:" appear in gptel's menu.
+
+See below for details on your preferred LLM provider, including local LLMs.
+
+**** (Optional) Securing API keys with =authinfo=
+
+You can use Emacs' built-in support for =authinfo= to store API keys required by gptel.  Add your API keys to =~/.authinfo=, and leave =gptel-api-key= set to its default.  By default, the API endpoint DNS name (e.g. "api.openai.com") is used as HOST and "apikey" as USER.
 #+begin_src authinfo
 machine api.openai.com login apikey password sk-secret-openai-api-key-goes-here
 machine api.anthropic.com login apikey password sk-secret-anthropic-api-key-goes-here
 #+end_src
 
-#+begin_src emacs-lisp
-(gptel-make-anthropic "Claude" :stream t :key gptel-api-key)
-#+end_src
-
-Once the backend is registered, you'll see model names prefixed by "Claude:" appear in the transient model selection menu.
-
-*** Other LLM backends
 #+html: <details><summary>
 **** Azure
 #+html: </summary>


### PR DESCRIPTION
* README.org: Move authinfo explanation to a new section, and make it clear that it's optional.  This builds on #715.