### PR TITLE
gptel-rewrite: Make rewrite work on Emacs < 29 again

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -363,7 +363,8 @@ OV is the rewrite overlay, CI is true for interactive calls."
            (concat
             (unless (eq (char-before (overlay-start ov)) ?\n) "\n")
             (propertize "REWRITE READY: " 'face 'success)
-            (mapconcat (lambda (e) (cdr e)) (mapcar #'rmc--add-key-description choices) ", ")
+	    (when (fboundp #'rmc--add-key-description)  ; introduced in Emacs 29
+              (mapconcat (lambda (e) (cdr e)) (mapcar #'rmc--add-key-description choices) ", "))
             (propertize
              " " 'display `(space :align-to (- right ,(1+ (length hint-str)))))
             (propertize hint-str 'face 'success)))


### PR DESCRIPTION
* gptel-rewrite.el (gptel--rewrite-dispatch): The function `rmc--add-key-description` was introduced in Emacs 29, resulting in an error for `gptel-rewrite`: "mapcar: Symbol’s function definition is void: rmc--add-key-description".  For older supported Emacs versions, skip this part to restore rewrite functionality, albeit with slightly reduced user guidance.  The actual rmc menu remains accessible in the minibuffer.