### PR TITLE
gptel-rewrite: Diff buffers, not files

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -292,10 +292,7 @@ BUF is the buffer to modify, defaults to the overlay buffer."
               ((buffer-live-p ov-buf)))
     (require 'diff)
     (let* ((newbuf (gptel--rewrite-prepare-buffer ovs))
-           (diff-buf (diff-no-select
-                      (if-let* ((buf-file (buffer-file-name ov-buf)))
-                          (expand-file-name buf-file) ov-buf)
-                      newbuf switches)))
+           (diff-buf (diff-no-select ov-buf newbuf switches)))
       (with-current-buffer diff-buf
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))


### PR DESCRIPTION
* gptel-rewrite.el (gptel--rewrite-diff): Show the difference between buffers rather than file names.  Otherwise, if a) the buffer has never been saved, the error "No such file or directory" will occur, or b) if there are unsaved changes in the buffer, the diff output will not reflect those changes.