### PR TITLE
Add gptel-register-tool function

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -1675,6 +1675,18 @@ callback as its first argument, which it runs with the result:
            nil nil #'equal)
           tool)))
 
+(defun gptel-register-tool (spec)
+  "Register a tool defined by SPEC with gptel.
+SPEC is a plist that can be passed to `gptel-make-tool'.  Add the tool
+to `gptel-tools', replacing any tool with the same name."
+  (let ((tool (apply #'gptel-make-tool spec)))
+    (setq gptel-tools
+          (cons tool (seq-remove
+                      (lambda (existing)
+                        (string= (gptel-tool-name existing)
+                                 (gptel-tool-name tool)))
+                      gptel-tools)))))
+
 (cl-defgeneric gptel--parse-tools (_backend tools)
   "Parse TOOLS and return a list of prompts.
 


### PR DESCRIPTION
* gptel.el (gptel-register-tool): New function to register a tool with
gptel, replacing any existing tool with the same name.

Following
https://github.com/skissue/llm-tool-collection/pull/2#issuecomment-2746561384