### PR TITLE
gptel-rewrite: Make other modes not clobber rewrite overlay

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -87,9 +87,9 @@ overlay."
 
 (defface gptel-rewrite-highlight-face
   '((((class color) (min-colors 88) (background dark))
-     :background "#041714" :extend t)
+     :background "#041714" :extend t :inherit default)
     (((class color) (min-colors 88) (background light))
-     :background "light goldenrod yellow" :extend t)
+     :background "light goldenrod yellow" :extend t :inherit default)
     (t :inherit secondary-selection))
   "Face for highlighting regions with pending rewrites."
   :group 'gptel)
@@ -434,6 +434,7 @@ INFO is the async communication channel for the rewrite request."
               (add-hook 'eldoc-documentation-functions #'gptel--rewrite-key-help nil 'local)
               ;; (overlay-put ov 'gptel-rewrite response)
               (overlay-put ov 'face 'gptel-rewrite-highlight-face)
+	      (overlay-put ov 'priority 2000)
               (overlay-put ov 'keymap gptel-rewrite-actions-map)
               (overlay-put ov 'mouse-face 'highlight)
               (overlay-put


### PR DESCRIPTION
When rewriting sections of Lisp or other code where the initial character is a parenthesis, it results in `show-paren-mode`highlighting the entire overlay when the point is positioned within the overlay area.  Avoid this issue by using a higher priority for `gptel-rewrite-highlight-face`.  (#691)

* gptel-rewrite.el (gptel-rewrite-highlight-face): Inherit from the `default'`face to avoid foreground being the same as `show-paren-match`, which is usually a reverse color. (gptel--rewrite-callback): Use priority higher than `show-paren-priority`.

---

I believe this fixes issue #691.