### PR TITLE
gptel-rewrite: Use correct form of `with-demoted-errors`

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -419,8 +419,8 @@ INFO is the async communication channel for the rewrite request."
             (let ((inhibit-read-only t))
               (delete-region (point) (point-max))
               ;; Run post-rewrite-functions on rewritten text in its buffer
-              (with-demoted-errors
-                  (run-hook-with-args 'gptel-post-rewrite-functions (point-min) (point-max)))
+              (with-demoted-errors "gptel-post-rewrite-functions: %S"
+                (run-hook-with-args 'gptel-post-rewrite-functions (point-min) (point-max)))
               (when (and (plist-get info :newline)
                          (not (eq (char-before (point-max)) ?\n)))
                 (insert "\n"))


### PR DESCRIPTION
Avoid these warnings:
Warning: Missing format argument in 'with-demoted-errors`

This was also suggested by Stefan Monnier in the emacs-devel mailing list.
