### PR TITLE
UTF-8 encoding issue in *ChatGPT* buffer

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -135,11 +135,10 @@ the response is inserted into the current buffer after point."
          (stream (plist-get info :stream))
          (process (apply #'start-process "gptel-curl"
                          (gptel--temp-buffer " *gptel-curl*") "curl" args)))
+    ;; Don't try to convert cr-lf to cr on Windows so that curl's "header size
+    ;; in bytes" stays correct. Explicitly set utf-8 for non-win systems too,
+    ;; for cases when buffer coding system is not set to utf-8.
     (set-process-coding-system process 'utf-8-unix 'utf-8-unix)
-    (when (memq system-type '(windows-nt ms-dos))
-      ;; Don't try to convert cr-lf to cr on Windows so that curl's "header size
-      ;; in bytes" stays correct
-      (set-process-coding-system process 'utf-8-unix 'utf-8-unix))
     (when (eq gptel-log-level 'debug)
       (gptel--log (mapconcat #'shell-quote-argument (cons "curl" args) " \\\n")
                   "request Curl command" 'no-json))

--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -135,6 +135,7 @@ the response is inserted into the current buffer after point."
          (stream (plist-get info :stream))
          (process (apply #'start-process "gptel-curl"
                          (gptel--temp-buffer " *gptel-curl*") "curl" args)))
+    (set-process-coding-system process 'utf-8-unix 'utf-8-unix)
     (when (memq system-type '(windows-nt ms-dos))
       ;; Don't try to convert cr-lf to cr on Windows so that curl's "header size
       ;; in bytes" stays correct

--- a/gptel.el
+++ b/gptel.el
@@ -2763,6 +2763,8 @@ the response is inserted into the current buffer after point."
                            (if (functionp backend-url)
                                (funcall backend-url) backend-url))
                          (lambda (_)
+                           (set-buffer-multibyte t)
+                           (set-buffer-file-coding-system 'utf-8-unix)
                            (pcase-let ((`(,response ,http-status ,http-msg ,error)
                                         (gptel--url-parse-response backend info))
                                        (buf (current-buffer)))


### PR DESCRIPTION
Bullet points (•) from GPT responses get incorrectly printed as `â\200¢` in the `*ChatGPT*` buffer.

The problem does not seem to happen if the process coding system is explicitly set to `utf-8-unix` when reading output from subprocesses.

Platform: Linux (Debian 12.5)

(I have been using gptel since around two weeks and it is great! Thank you karthink.)

Below is a screenshot of the incorrect printing of bullets:

![encoding-issue](https://github.com/user-attachments/assets/c254366b-e9f5-456c-83a3-3f5924f8f11e)

Below is a screenshot after this code commit.

![encoding-issue-fix](https://github.com/user-attachments/assets/d845aeda-4323-4909-8654-0a4c313c126c)
