### PR TITLE
Allow tool use if `gptel-use-tools` was non-nil at request time

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2132,10 +2132,10 @@ Run post-response hooks."
 (defun gptel--error-p (info) (plist-get info :error))
 
 (defun gptel--tool-use-p (info)
-  (and gptel-use-tools (plist-get info :tool-use)))
+  (and (plist-get info :tools) (plist-get info :tool-use)))
 
 (defun gptel--tool-result-p (info)
-  (and gptel-use-tools (plist-get info :tool-success)))
+  (and (plist-get info :tools) (plist-get info :tool-success)))
 
 
 ;;; Send queries, handle responses


### PR DESCRIPTION
Currently, something like this simply terminates when the LLM tries to invoke a tool:

```elisp
;; Tools disabled by default.
(setq gptel-use-tools nil)
(setq gptel-tools my-tools)

;; Enable tools for a specific request.
(let ((gptel-use-tools t))
  (gptel-request "Do something with the tools"))
```

The proposed changes allow the LLM to use tools based on the request-time value of `gptel-use-tools`, rather than its value when the actual tool use is attempted.

Note: this slightly changes the existing behavior in the (unexpected) edge case where `gptel-use-tools` is globally non-nil and `gptel-tools` is nil at request time, but the LLM tries to use a tool anyway. In that case, these functions now return nil (because `:tools` never gets set on the context object) and the request simply terminates, whereas previously they would return non-nil and an error would be thrown when the tool isn't found. This error-vs-terminate behavior is already currently dependent on the value of `gptel-use-tools` (i.e. unknown tool use will throw an error when `gptel-use-tools` is non-nil, but simply terminate when nil); an alternate approach would be to just remove the check for `gptel-use-tools` or `(plist-get info :tools)` all together, and simply let the "Unknown tool" error get thrown in all unknown-tool cases.