### PR TITLE
Insert newlines after streaming tool results

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -264,6 +264,9 @@ Optional RAW disables text properties and transformation."
              (set-marker-insertion-type tracking-marker t)
              (plist-put info :tracking-marker tracking-marker))
            (goto-char tracking-marker)
+           (when (plist-get info :last-was-tool-result)
+             (insert gptel-response-separator)
+             (plist-put info :last-was-tool-result nil))
            (unless raw
              (when transformer
                (setq response (funcall transformer response)))
@@ -278,7 +281,8 @@ Optional RAW disables text properties and transformation."
     (`(tool-call . ,tool-calls)
      (gptel--display-tool-calls tool-calls info))
     (`(tool-result . ,tool-results)
-     (gptel--display-tool-results tool-results info))))
+     (gptel--display-tool-results tool-results info)
+     (plist-put info :last-was-tool-result t))))
 
 (defun gptel-curl--stream-filter (process output)
   (let* ((fsm (alist-get process gptel--request-alist))


### PR DESCRIPTION
This is a fix for #769. It ensures that we insert a `gptel-response-separator` after a tool result comes in in streaming mode. This prevents weird formatting when `gptel-include-tool-results` is `nil` and the tool result came in between two chat responses (see the linked issue for details).