### PR TITLE
docs: update xAI backend with Grok 3 model variants

### DIFF
--- a/README.org
+++ b/README.org
@@ -864,14 +864,9 @@ The above code makes the backend available to select.  If you want it to be the 
 
 Register a backend with
 #+begin_src emacs-lisp
-;; xAI offers an OpenAI compatible API
-(gptel-make-openai "xAI"           ;Any name you want
-  :host "api.x.ai"
-  :key "your-api-key"              ;can be a function that returns the key
-  :endpoint "/v1/chat/completions"
+(gptel-make-xai "xAI"                   ; Any name you want
   :stream t
-  :models '(;; xAI now only offers `grok-beta` as of the time of this writing
-            grok-beta))
+  :key "your-api-key")                  ; can be a function that returns the key
 #+end_src
 
 You can pick this backend from the menu when using gptel (see [[#usage][Usage]])
@@ -880,17 +875,11 @@ You can pick this backend from the menu when using gptel (see [[#usage][Usage]])
 
 The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.
 #+begin_src emacs-lisp
-;; OPTIONAL configuration
-(setq
- gptel-model   'grok-beta
- gptel-backend
- (gptel-make-openai "xAI"           ;Any name you want
-   :host "api.x.ai"
-   :key "your-api-key"              ;can be a function that returns the key
-   :endpoint "/v1/chat/completions"
-   :stream t
-   :models '(;; xAI now only offers `grok-beta` as of the time of this writing
-             grok-beta)))
+(setq gptel-model 'grok-3-latest
+      gptel-backend
+      (gptel-make-xai "xAI"               ; Any name you want
+                      :key "your-api-key" ; can be a function that returns the key
+                      :stream t))
 #+end_src
 
 #+html: </details>

--- a/README.org
+++ b/README.org
@@ -878,8 +878,8 @@ The above code makes the backend available to select.  If you want it to be the 
 (setq gptel-model 'grok-3-latest
       gptel-backend
       (gptel-make-xai "xAI"               ; Any name you want
-                      :key "your-api-key" ; can be a function that returns the key
-                      :stream t))
+        :key "your-api-key" ; can be a function that returns the key
+        :stream t))
 #+end_src
 
 #+html: </details>

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -363,5 +363,66 @@ The Deepseek API requires strictly alternating roles (user/assistant) in message
     (setf (alist-get name gptel--known-backends nil nil #'equal) backend)
     backend))
 
+;;;###autoload
+(cl-defun gptel-make-xai
+    (name &key curl-args stream key request-params
+          (header (lambda () (when-let* ((key (gptel--get-api-key)))
+                               `(("Authorization" . ,(concat "Bearer " key))))))
+          (host "api.x.ai")
+          (protocol "https")
+          (endpoint "/v1/chat/completions")
+          (models '((grok-3-latest
+                     :description "Grok 3"
+                     :capabilities '(tool-use json)
+                     :context-window 131072
+                     :input-cost 3
+                     :output-cost 15)
+
+                    (grok-3-fast-latest
+                     :description "Faster Grok 3"
+                     :capabilities '(tool-use json)
+                     :context-window 131072
+                     :input-cost 5
+                     :output-cost 25)
+
+                    (grok-3-mini-latest
+                     :description "Mini Grok 3"
+                     :capabilities '(tool-use json reasoning)
+                     :context-window 131072
+                     :input-cost 0.3
+                     :output-cost 0.5)
+
+                    (grok-3-mini-fast-latest
+                     :description "Faster mini Grok 3"
+                     :capabilities '(tool-use json reasoning)
+                     :context-window 131072
+                     :input-cost 0.6
+                     :output-cost 4)
+
+                    (grok-2-vision-1212
+                     :description "Grok 2 Vision"
+                     :capabilities '(tool-use json)
+                     :mime-types '("image/jpeg" "image/png" "image/gif" "image/webp")
+                     :context-window 32768
+                     :input-cost 2
+                     :output-cost 10))))
+  "Register an xAI backend for gptel with NAME."
+  (declare (indent 1))
+  (let ((backend (gptel--make-openai
+                  :name name
+                  :host host
+                  :header header
+                  :key key
+                  :models (gptel--process-models models)
+                  :protocol protocol
+                  :endpoint endpoint
+                  :stream stream
+                  :request-params request-params
+                  :curl-args curl-args
+                  :url (concat protocol "://" host endpoint))))
+    (setf (alist-get name gptel--known-backends nil nil #'equal) backend)
+    backend))
+
+
 (provide 'gptel-openai-extras)
 ;;; gptel-openai-extras.el ends here

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -363,11 +363,12 @@ The Deepseek API requires strictly alternating roles (user/assistant) in message
     (setf (alist-get name gptel--known-backends nil nil #'equal) backend)
     backend))
 
+;;; xAI
 ;;;###autoload
 (cl-defun gptel-make-xai
     (name &key curl-args stream key request-params
           (header (lambda () (when-let* ((key (gptel--get-api-key)))
-                               `(("Authorization" . ,(concat "Bearer " key))))))
+                          `(("Authorization" . ,(concat "Bearer " key))))))
           (host "api.x.ai")
           (protocol "https")
           (endpoint "/v1/chat/completions")
@@ -406,7 +407,18 @@ The Deepseek API requires strictly alternating roles (user/assistant) in message
                      :context-window 32768
                      :input-cost 2
                      :output-cost 10))))
-  "Register an xAI backend for gptel with NAME."
+  "Register an xAI backend for gptel with NAME.
+
+Keyword arguments:
+
+KEY is a variable whose value is the API key, or function that
+returns the key.
+
+STREAM is a boolean to toggle streaming responses, defaults to
+false.
+
+The other keyword arguments are all optional.  For their meanings
+see `gptel-make-openai'."
   (declare (indent 1))
   (let ((backend (gptel--make-openai
                   :name name


### PR DESCRIPTION
Note: xAI has an image generation model, but it's served from a different endpoint, and I'm not sure how well it work with GPTel. I also opted to choose the "latest" variants for these models based off of the description on the model page:

[xAI Model Overview](https://docs.x.ai/docs/models)