### PR TITLE
allow customize-variable to set temperature to nil

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -481,8 +481,9 @@ of the response, with 2.0 being the most random.
 
 To set the temperature for a chat session interactively call
 `gptel-send' with a prefix argument."
-  :safe #'always
-  :type 'number)
+  :safe (lambda (v) (or (null v) (numberp v)))
+  :type '(choice (number :tag "Temperature value")
+                 (const :tag "Use default" nil)))
 
 (defcustom gptel-cache nil
   "Whether the LLM should cache request content.


### PR DESCRIPTION
Usually I set the temperature to nil to allow the backend to use its default temp, but I noticed customize-variable doesn't provide that as an option, and setopt complains about nil not being a number.