### PR TITLE
Fix pairing of details tags

### DIFF
--- a/README.org
+++ b/README.org
@@ -897,7 +897,6 @@ The above code makes the backend available to select.  If you want it to be the 
 
 #+html: </details>
 
-#+html: </details>
 #+html: <details><summary>
 **** Github CopilotChat
 #+html: </summary>
@@ -918,6 +917,8 @@ The above code makes the backend available to select.  If you want it to be the 
 (setq gptel-model 'claude-3.7-sonnet
       gptel-backend (gptel-make-gh-copilot "Copilot"))
 #+end_src
+
+#+html: </details>
 
 ** Usage
 


### PR DESCRIPTION
It looks like there was a mismatched copy/paste in #767 which caused the entire "Usage" section of the README to be hidden by default in GitHub's viewer (revealed only by expanding the Copilot Chat instructions). This is just a change to close the tag as needed and bring back the missing section.

Before:
<img width="289" alt="image" src="https://github.com/user-attachments/assets/e8bb3ada-eafc-4db0-8032-791c7e65d603" />

After:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/1d9c68d7-b68c-44cd-9776-338005f16d6d" />
