### PR TITLE
Improve gptel-org-set-topic to not include tags in the default value

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -184,7 +184,7 @@ current heading and the cursor position."
                                  (substring-no-properties
                                   (replace-regexp-in-string
                                    "\\s-+" "-"
-                                   (org-get-heading)))
+                                   (org-entry-get nil "ITEM")))
                                  50))))))
   (when (stringp topic) (org-set-property "GPTEL_TOPIC" topic)))
 


### PR DESCRIPTION
If the source heading has any tag, the result of `org-get-heading` contains the tag string. By using `org-entry-get` to retrieve the `ITEM` property of the entry, you can get the true heading of the entry, which would be more suitable unless you want to include the tags in the topic.