### PR TITLE
Allow uppercase characters when creating tool key shortcuts

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -803,9 +803,11 @@ only (\"oneshot\")."
         (cl-loop                    ;for each category, collect tools as infixes
          for (name . tool) in tools-alist
          with tool-keys = (delete category-key (nconc (number-sequence ?a ?z)
-                                                      (number-sequence ?0 ?9)))
-         for tool-key = (seq-find (lambda (k) (member k tool-keys)) name
-                                  (seq-first tool-keys))
+                                                      (number-sequence ?0 ?9)
+                                                      (number-sequence ?A ?Z)))
+         for tool-key = (or (seq-find (lambda (k) (member k tool-keys)) name)
+                            (seq-find (lambda (k) (member k tool-keys)) (upcase name)
+                                      (seq-first tool-keys)))
          do (setq tool-keys (delete tool-key tool-keys))
          collect           ;Each list is a transient infix of type gptel--switch
          (list (key-description (list category-key tool-key))


### PR DESCRIPTION
This PR allows the use of uppercase characters when creating key shortcuts for tools. 
This would be beneficial for tools like github mcp which provides more than 26 tools