### PR TITLE
Gemini: parse code execution and grounding result

### DIFF
--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -72,36 +72,70 @@ Mutate state INFO with response metadata.
 If INCLUDE-TEXT is non-nil, include response text in the prompts
 list."
   (let* ((cand0 (map-nested-elt response '(:candidates 0)))
-         (parts (map-nested-elt cand0 '(:content :parts))))
+         (parts (map-nested-elt cand0 '(:content :parts)))
+         (grounding-meta (plist-get cand0 :groundingMetadata)))
     (plist-put info :stop-reason (plist-get cand0 :finishReason))
     (plist-put info :output-tokens
                (map-nested-elt
                 response '(:usageMetadata :candidatesTokenCount)))
-    (cl-loop
-     for part across parts
-     for tx = (plist-get part :text)
-     if (and tx (not (eq tx :null))) collect tx into content-strs
-     else if (plist-get part :functionCall)
-     collect (copy-sequence it) into tool-use
-     finally do                         ;Add text and tool-calls to prompts list
-     (when (or tool-use include-text)
-       (let* ((data (plist-get info :data))
-              (prompts (plist-get data :contents))
-              (last-prompt (aref prompts (1- (length prompts)))))
-         (if (equal (plist-get last-prompt :role) "model")
-             ;; When streaming, the last prompt may already have the role
-             ;; "model" from prior calls to this function.  Append to its parts
-             ;; instead of adding a new model role then.
-             (plist-put last-prompt :parts
-                        (vconcat (plist-get last-prompt :parts) parts))
-           (plist-put                   ;otherwise create a new "model" role
-            data :contents
-            (vconcat prompts `((:role "model" :parts ,parts)))))))
-     (when tool-use                    ;Capture tool call data for running tools
-       (plist-put info :tool-use
-                  (nconc (plist-get info :tool-use) tool-use)))
-     finally return
-     (and content-strs (apply #'concat content-strs)))))
+    (concat
+     ;; text parts and tool-use
+     (cl-loop
+      for part across parts
+      for tx = (plist-get part :text)
+      if (and tx (not (eq tx :null))) collect tx into content-strs
+      else if (plist-get part :functionCall)
+      collect (copy-sequence it) into tool-use
+      finally do                         ;Add text and tool-calls to prompts list
+      (when (or tool-use include-text)
+        (let* ((data (plist-get info :data))
+               (prompts (plist-get data :contents))
+               (last-prompt (aref prompts (1- (length prompts)))))
+          (if (equal (plist-get last-prompt :role) "model")
+              ;; When streaming, the last prompt may already have the role
+              ;; "model" from prior calls to this function.  Append to its parts
+              ;; instead of adding a new model role then.
+              (plist-put last-prompt :parts
+                         (vconcat (plist-get last-prompt :parts) parts))
+            (plist-put                   ;otherwise create a new "model" role
+             data :contents
+             (vconcat prompts `((:role "model" :parts ,parts)))))))
+      (when tool-use                    ;Capture tool call data for running tools
+        (plist-put info :tool-use
+                   (nconc (plist-get info :tool-use) tool-use)))
+      finally return
+      (and content-strs (apply #'concat content-strs)))
+     ;; executable code and result
+     (cl-loop
+      for part across parts
+      collect (or (when-let ((executable-code (plist-get part :executableCode)))
+                    (format "Executing code:\n\n```%s\n%s\n```\n"
+                            (downcase (plist-get executable-code :language))
+                            (plist-get executable-code :code)))
+                  (when-let ((execution-result (plist-get part :codeExecutionResult)))
+                    (format "Execution result (%s): %s\n"
+                            (plist-get execution-result :outcome)
+                            (plist-get execution-result :output))))
+      into content-strs
+      finally return
+      (and content-strs (apply #'concat content-strs)))
+     ;; grounding metadata
+     (when grounding-meta
+       (concat
+        "\n"
+        (when-let ((queries (plist-get grounding-meta :webSearchQueries)))
+          (concat
+           "\nGrounding web search queries: "
+           (string-join (seq-into queries 'list) ", ")))
+        (when-let ((chunks (plist-get grounding-meta :groundingChunks)))
+          (cl-loop
+           for chunk across chunks
+           collect (format "- [%s](%s)\n"
+                           (map-nested-elt chunk '(:web :title))
+                           (map-nested-elt chunk '(:web :uri)))
+           into chunk-strs
+           finally return
+           (and chunk-strs (concat "\nGroundings:\n" (apply #'concat chunk-strs))))))))))
 
 (cl-defmethod gptel--request-data ((backend gptel-gemini) prompts)
   "JSON encode PROMPTS for sending to Gemini."


### PR DESCRIPTION
(I'm not sure if this feature is desired or not. This is a draft version. Please let me know how you think.)

Gemini model support builtin tools including google search (grounding) and code execution. Now users can use `:request-params` to add support for them (https://github.com/karthink/gptel/issues/750#issuecomment-2815590261 ). This PR extends the parsing function for Gemini to print grounding and code execution results. (We may need better ways other than custom `:request-params` to support these tools, but that's for future PRs)

<img width="796" alt="Screenshot 2025-04-27 at 21 55 21" src="https://github.com/user-attachments/assets/afb98236-e00a-42df-add7-6afdd05d0efd" />
<img width="798" alt="Screenshot 2025-04-27 at 21 55 56" src="https://github.com/user-attachments/assets/cbcf6396-047b-42c0-8e36-fdfddeeff7de" />
