### PR TITLE
gptel-openai: gptel--request-data get reasoning capability from prop

### DIFF
--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -296,8 +296,8 @@ Mutate state INFO with response metadata."
          `(:model ,(gptel--model-name gptel-model)
            :messages [,@prompts]
            :stream ,(or gptel-stream :json-false)))
-        (reasoning-model-p ; TODO: Embed this capability in the model's properties
-         (memq gptel-model '(o1 o1-preview o1-mini o3-mini o3 o4-mini))))
+        (reasoning-model-p
+         (gptel--model-capable-p 'reasoning)))
     (when (and gptel-temperature (not reasoning-model-p))
       (plist-put prompts-plist :temperature gptel-temperature))
     (when gptel-use-tools


### PR DESCRIPTION
The models with reasoning capabilities were hard-coded in openai's `gptel--request-data`. This PR replaces it with `gptel--model-capable-p` to get the reasoning capabilities from the model properties.

This came about when I started playing with `gpt-4o-search-preview` and `gpt-4o-mini-search-preview`, which seems to not support `temperature`. I was adding the reasoning capability, which seems to resolve that issue for now. Is it also worth considering `temperature` as another capability?