### PR TITLE
Add `gemini-2.5-pro-preview-05-06` model to `gptel-gemini.el`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@
 
 - Add support for ~gemini-2.5-flash-preview-04-17~.
 
+- Add support for ~gemini-2.5-pro-preview-05-06~.
+
 ** New features and UI changes
 
 - The new option ~gptel-curl-extra-args~ can be used to specify extra

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -462,6 +462,15 @@ files in the context."
      :input-cost 0.15
      :output-cost 0.60 ; 3.50 for thinking
      :cutoff-date "2025-01")
+    (gemini-2.5-pro-preview-05-06
+     :description "Most powerful Gemini thinking model with maximum response accuracy and state-of-the-art performance"
+     :capabilities (tool-use json media)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html")
+     :context-window 1000
+     :input-cost 1.25 ; 2.50 for >200k tokens
+     :output-cost 10.00 ; 15 for >200k tokens
+     :cutoff-date "2025-01")
     (gemini-2.0-flash-thinking-exp
      :description "DEPRECATED: Please use gemini-2.0-flash-thinking-exp-01-21 instead."
      :capabilities (tool-use media)


### PR DESCRIPTION
This PR adds Gemini 2.5 Pro Preview (I/O edition): https://developers.googleblog.com/en/gemini-2-5-pro-io-improved-coding-performance/