### PR TITLE
gptel-gh: Add media capability to GitHub Copilot gpt-4.1 model

### DIFF
--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -41,7 +41,7 @@
      :cutoff-date "2023-10")
     (gpt-4.1
      :description "Flagship model for complex tasks"
-     :capabilities (tool-use json url)
+     :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
      :context-window 1024
      :input-cost 2.0


### PR DESCRIPTION
The gpt-4.1 models appear to support media/"vision" when used via GitHub Copilot, and thus this PR aligns the capabilities of this model in `gptel--gh-models` to the capabilities of this model in `gptel--openai-models`.