### PR TITLE
Update gemini-2.5-flash-preview to latest model code.

### DIFF
--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -463,6 +463,15 @@ files in the context."
      :input-cost 0.15
      :output-cost 0.60 ; 3.50 for thinking
      :cutoff-date "2025-01")
+    (gemini-2.5-flash-preview-05-20
+     :description "Best Gemini model in terms of price-performance, offering well-rounded capabilities"
+     :capabilities (tool-use json media)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html")
+     :context-window 1048 ; 65536 output token limit
+     :input-cost 0.15
+     :output-cost 0.60 ; 3.50 for thinking
+     :cutoff-date "2025-01")
     (gemini-2.5-pro-preview-05-06
      :description "Most powerful Gemini thinking model with maximum response accuracy and state-of-the-art performance"
      :capabilities (tool-use json media)


### PR DESCRIPTION
I guess there is no rush since the 04-17 endpoint still works (not sure if that is still the old model or if it is already being redirected to the new version). But eventually the old preview models are usually phased out leading to 404 or similar.

See:
 - https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-preview
 - https://ai.google.dev/gemini-api/docs/models#previous-experimental-models

EDIT: ~~Or perhaps I should duplicate the existing entry? Would be less disruptive to peoples configs I guess?~~ ✓