### PR TITLE
feat(context): display full file paths instead of filenames only

### DIFF
--- a/gptel-context.el
+++ b/gptel-context.el
@@ -395,7 +395,7 @@ START and END signify the region delimiters."
 
 (defun gptel-context--insert-file-string (path)
   "Insert at point the contents of the file at PATH as context."
-  (insert (format "In file `%s`:" (file-name-nondirectory path))
+  (insert (format "In file `%s`:" path)
           "\n\n```\n")
   (insert-file-contents path)
   (goto-char (point-max))
@@ -478,7 +478,7 @@ context overlays, see `gptel-context--alist'."
                         (overlay-put ov 'evaporate t)
                         (insert "\n" (make-separator-line) "\n"))
                     ;; BUF is a file path, not a buffer
-                    (insert (propertize (format "In file %s:\n\n" (file-name-nondirectory buf))
+                    (insert (propertize (format "In file %s:\n\n" buf)
                                         'face 'bold))
                     (setq beg (point))
                     (if-let* ((mime (plist-get ovs :mime)))


### PR DESCRIPTION
Show complete file paths when adding files to context instead of just the basename. This enables LLMs to:

  - Use file paths correctly when calling tools/functions
  - Understand semantic meaning from directory structure
  - Distinguish between files with identical names in different locations

---

Longer explanation:

### Problem

Currently, when adding files to the LLM context via `gptel-context`, only the filename (basename) is displayed to both the user and the LLM. This creates two significant limitations:

1. **Tool/Function calling**: When LLMs need to use tools or functions that operate on files, they require the full path to correctly reference the file. Providing only the filename makes it impossible for the LLM to construct valid file operations.

2. **Semantic context loss**: File paths often contain meaningful semantic information about the codebase structure. For example:
   - `docs/api/README.md` vs `docs/user/README.md` vs `README.md`

   The directory structure provides crucial context about the file's purpose and relationship to other parts of the project.

### Solution

This change modifies the context insertion functions in `gptel-context.el` to display the full file path instead of just the filename:

- `gptel-context--insert-file-string`: Now shows full path in the context header
- Context overlay insertion: Now shows full path when adding file-based context
