### PR TITLE
Add `gemini-2.5-pro-preview-06-05` model to `gptel-gemini.el`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,8 +30,8 @@
 - Add support for ~gpt-4.1~, ~gpt-4.1-mini~, ~gpt-4.1-nano~, ~o3~ and
   ~o4-mini~.
 
-- Add support for ~gemini-2.5-pro-exp-03-25~,
-  ~gemini-2.5-flash-preview-04-17~ and ~gemini-2.5-pro-preview-05-06~.
+- Add support for ~gemini-2.5-pro-exp-03-25~, ~gemini-2.5-flash-preview-04-17~,
+  ~gemini-2.5-pro-preview-05-06~ and ~gemini-2.5-pro-preview-06-05~.
 
 - Add support for ~claude-sonnet-4-20250514~ and
   ~claude-opus-4-20250514~.

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -488,11 +488,20 @@ files in the context."
      :output-cost 0.60 ; 3.50 for thinking
      :cutoff-date "2025-01")
     (gemini-2.5-pro-preview-05-06
-     :description "Most powerful Gemini thinking model with maximum response accuracy and state-of-the-art performance"
+     :description "Previously the most powerful Gemini thinking model with state-of-the-art performance"
      :capabilities (tool-use json media)
      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
                   "application/pdf" "text/plain" "text/csv" "text/html")
-     :context-window 1000
+     :context-window 1048 ; 65536 output token limit
+     :input-cost 1.25 ; 2.50 for >200k tokens
+     :output-cost 10.00 ; 15 for >200k tokens
+     :cutoff-date "2025-01")
+    (gemini-2.5-pro-preview-06-05
+     :description "Most powerful Gemini thinking model with state-of-the-art performance"
+     :capabilities (tool-use json media)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html")
+     :context-window 1048 ; 65536 output token limit
      :input-cost 1.25 ; 2.50 for >200k tokens
      :output-cost 10.00 ; 15 for >200k tokens
      :cutoff-date "2025-01")


### PR DESCRIPTION
Gemini 2.5 Pro Preview 06-05: https://blog.google/products/gemini/gemini-2-5-pro-latest-preview/

This time they stated this is the last update of 2.5 Pro before GA...