### PR TITLE
gptel: Fix warnings when specifying `:pre` or `:post` in a preset

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -3670,7 +3670,7 @@ PRESET is a spec (plist) of keys and values."
     (while index
       (setq key (pop index) val (pop index))
       (pcase key
-        (:description)
+        ((or :description :pre :post))
         (:parents
          (mapc (lambda (parent-preset)
                  (nconc syms (gptel--preset-syms


### PR DESCRIPTION
This fixes stray warnings like `Warning (gptel): gptel preset ":description": setting for :pre not found, ignoring.`.