### PR TITLE
Fix invalid use of transient-scope with arguments

### DIFF
--- a/gptel-integrations.el
+++ b/gptel-integrations.el
@@ -220,7 +220,7 @@ from all connected servers if it is nil."
          nil (lambda () (when-let* ((transient--prefix)
                                ((eq (oref transient--prefix command)
                                     'gptel-tools)))
-                     (let ((state (transient-scope 'gptel-tools)))
+                     (let ((state (transient-scope)))
                        (plist-put state :tools
                                   (delete-dups
                                    (nconc (mapcar (lambda (tool)
@@ -250,7 +250,7 @@ from all connected servers if it is nil."
     (call-interactively #'gptel-mcp-disconnect)
     ;; gptel-tools stores its state in its scope slot.  Retain the scope but
     ;; remove tools from it that no longer exist, then set up gptel-tools
-    (cl-loop with state = (transient-scope 'gptel-tools)
+    (cl-loop with state = (transient-scope)
              with tools = (plist-get state :tools)
              for tool-spec in tools
              if (map-nested-elt gptel--known-tools tool-spec)

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -994,7 +994,7 @@ only (\"oneshot\")."
      (lambda (tools)
        ;; We don't care about the transient args of this prefix at all, since
        ;; the state is managed entirely through its transient-scope:
-       (interactive (list (plist-get (transient-scope 'gptel-tools) :tools)))
+       (interactive (list (plist-get (transient-scope) :tools)))
        (gptel--set-with-scope
         'gptel-tools
         (mapcar (lambda (category-and-name)


### PR DESCRIPTION
Hi!  Thank you for this excellent package — I've been integrating gptel into my Emacs workflow and ran into an issue when calling transient-based commands with the newest stable version of Emacs.

Some recent versions of Emacs (e.g. 30.1.50+) now enforce the arity of transient-scope.  It's a no-argument function, but in a few places in the code, it's currently being called like:

    _(transient-scope 'gptel-tools)_

This raises an error:

    _(wrong-number-of-arguments #<subr transient-scope> 1)_

This PR replaces all such calls with the correct zero-argument form:

    _(transient-scope)_
    
It was only a couple of occurrences:
    - gptel-integrations.el
    - gptel-transient.el
    
 