### PR TITLE
Don't pin compat. transient has already pinned compat

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Karthik Chikmagalur <karthik.chikmagalur@gmail.com>
 ;; Version: 0.9.8.5
-;; Package-Requires: ((emacs "27.1") (transient "0.7.4") (compat "29.1.4.1"))
+;; Package-Requires: ((emacs "27.1") (transient "0.7.4"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/karthink/gptel
 


### PR DESCRIPTION
Thank you for your nice tool. 

When I install gptel like https://github.com/mqcmd196/dotfiles/pull/95 , I found that the latest transient is installed but the compat>=30 is not installed using `use-package` . This causes the missing of `static-if` and breaks some packages using transient.

It seems that transient already has compat >= 30 dependency https://github.com/magit/transient/blob/b2cb4e578f2362a0354c4a31a6bd89d6c4b63d63/lisp/transient.el#L10 . I'm not sure about emacs packaging system but my bet is deleting pinning compat or writing compat >=30 in gptel would fix the issue. 

I confirmed my init.el works when I install compat >= 30 manually.

I use emacs 29 in Ubuntu 24.04 . 

```
❯ apt show emacs
Package: emacs
Version: 1:29.3+1-1ubuntu2
Priority: optional
Section: universe/editors
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Rob Browning <rlb@defaultvalue.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 54.3 kB
Depends: emacs-gtk (>= 1:27.1) | emacs-pgtk (>= 1:27.1) | emacs-lucid (>= 1:27.1) | emacs-nox (>= 1:27.1)
Homepage: https://www.gnu.org/software/emacs/
Download-Size: 19.9 kB
APT-Manual-Installed: yes
APT-Sources: http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages
Description: GNU Emacs editor (metapackage)
 GNU Emacs is the extensible self-documenting text editor.
 This is a metapackage that will always depend on the latest
 recommended Emacs variant (currently emacs-gtk).
``` 