### PR TITLE
gptel-gemini: add `gemini-2.5-flash-lite` GA model

### DIFF
--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -503,9 +503,9 @@ files in the context."
                   "application/pdf" "text/plain" "text/csv" "text/html"
                   "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
                   "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
-     :context-window 1024
-     :input-cost 0.15
-     :output-cost 0.60
+     :context-window 1048 ; 65536 output token limit
+     :input-cost 0.3
+     :output-cost 2.50
      :cutoff-date "2025-01")
     (gemini-2.5-pro-preview-05-06
      :description "Previously most powerful thinking model with state-of-the-art performance"
@@ -526,22 +526,29 @@ files in the context."
      :output-cost 10.00 ; 15 for >200k tokens
      :cutoff-date "2025-01")
     (gemini-2.5-flash-lite-preview-06-17
-     :description "A Gemini 2.5 Flash model optimized for cost efficiency and low latency"
-     :capabilities (tool-use json media)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                  "application/pdf" "text/plain" "text/csv" "text/html")
-     :context-window 1000 ; 64000 output token limit
+     :description "Fastest and cheapest 2.5 model, for high-volume, latency-sensitive tasks."
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "application/pdf" "text/plain"
+                  "audio/x-aac" "audio/flac" "audio/mp3" "audio/m4a" "audio/mpeg"
+                  "audio/mpga" "audio/mp4" "audio/opus" "audio/pcm" "audio/wav" "audio/webm"
+                  "video/x-flv" "video/quicktime" "video/mpeg" "video/mp4"
+                  "video/webm" "video/wmv" "video/3gpp")
+     :context-window 1048 ; 65536 output token limit
      :input-cost 0.10
      :output-cost 0.40
      :cutoff-date "2025-01")
-    (gemini-2.5-flash
-     :description "Best model in terms of price-performance, offering well-rounded capabilities."
+    (gemini-2.5-flash-lite
+     :description "Fastest and cheapest 2.5 model, for high-volume, latency-sensitive tasks."
      :capabilities (tool-use json media)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                  "application/pdf" "text/plain" "text/csv" "text/html")
-     :context-window 1048 ; 65536 output token limit
-     :input-cost 0.3
-     :output-cost 2.50
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "application/pdf" "text/plain"
+                  "audio/x-aac" "audio/flac" "audio/mp3" "audio/m4a" "audio/mpeg"
+                  "audio/mpga" "audio/mp4" "audio/opus" "audio/pcm" "audio/wav" "audio/webm"
+                  "video/x-flv" "video/quicktime" "video/mpeg" "video/mp4"
+                  "video/webm" "video/wmv" "video/3gpp")
+     :context-window 1048 ; 64000 output token limit
+     :input-cost 0.10
+     :output-cost 0.40
      :cutoff-date "2025-01")
     (gemini-2.5-pro
      :description "Most powerful Gemini thinking model with state-of-the-art performance"
@@ -553,18 +560,6 @@ files in the context."
      :context-window 1048               ; 65536 output token limit
      :input-cost 1.25                   ; 2.50 for >200k tokens
      :output-cost 10.00                 ; 15 for >200k tokens
-     :cutoff-date "2025-01")
-    (gemini-2.5-flash-lite-preview-06-17
-     :description "Fastest and cheapest 2.5 model, for high-volume, latency-sensitive tasks."
-     :capabilities (tool-use json media audio video)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "application/pdf" "text/plain"
-                  "audio/x-aac" "audio/flac" "audio/mp3" "audio/m4a" "audio/mpeg"
-                  "audio/mpga" "audio/mp4" "audio/opus" "audio/pcm" "audio/wav" "audio/webm"
-                  "video/x-flv" "video/quicktime" "video/mpeg" "video/mp4"
-                  "video/webm" "video/wmv" "video/3gpp")
-     :context-window 1048
-     :input-cost 0.075
-     :output-cost 0.30
      :cutoff-date "2025-01")
     (gemini-2.0-flash-thinking-exp
      :description "DEPRECATED: Please use gemini-2.0-flash-thinking-exp-01-21 instead."


### PR DESCRIPTION
Announcement: https://developers.googleblog.com/en/gemini-25-flash-lite-is-now-stable-and-generally-available/
Documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-lite

Also, remove duplicate definitions and correct the pricing of `gemini-2.5-flash-lite-preview-06-17` and `gemini-2.5-flash`, introduced in:
  - https://github.com/karthink/gptel/pull/913
  - https://github.com/karthink/gptel/pull/926