### PR TITLE
Fix invalid type char-or-string-p when inserting nil for gptel--system-message

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1779,7 +1779,8 @@ setting up the buffer."
         (set-marker msg-start (point))
         (save-excursion
           ;; If it's a list, insert only the system message part
-          (insert (or initial (car-safe (gptel--parse-directive directive 'raw))))
+          ;; If all is nil, insert "" at least
+          (insert (or initial (car-safe (gptel--parse-directive directive 'raw)) ""))
           (push-mark nil 'nomsg))
         (and (functionp setup) (funcall setup)))
       (display-buffer (current-buffer)


### PR DESCRIPTION
If gptel--system-message and gptel directives are nil, we erroneously call (insert nil). We add "" to ensure non-nil is inserted into the buffer.

To currently reproduce the error; set `gptel--system-message` to nil, then attempt to call the manual edit system message option from the transient `gptel-menu`.

```emacs-lisp
Debugger entered--Lisp error: (wrong-type-argument char-or-string-p nil)
  transient--exit-and-debug(error (wrong-type-argument char-or-string-p nil))
  gptel--edit-directive(gptel--system-message :setup activate-mark)
  #<subr gptel--suffix-system-message>(nil)
  apply(#<subr gptel--suffix-system-message> nil)
  #f(compiled-function (fn &rest args) (interactive nil) #<bytecode -0x1569efc26de924f3>)(#<subr gptel--suffix-system-message> nil)
  funcall-interactively(#f(compiled-function (fn &rest args) (interactive nil) #<bytecode -0x1569efc26de924f3>) #<subr gptel--suffix-system-message> nil)
  apply(funcall-interactively #f(compiled-function (fn &rest args) (interactive nil) #<bytecode -0x1569efc26de924f3>) (#<subr gptel--suffix-system-message> nil))
  #[128 "\302\303\304!\203\13\0\305\202\f\0\306\300\3#\207" [#[385 "\305\306\300\301\303$\216\307\34\302\205\21\0\310\302\311\"\211\205.\0\310\302\312\"\206.\0\310\302\313\"\206.\0\310\1\312\"\206.\0\310\1\313\"\211\203:\0\314\1\5\5#\202>\0\314\4\4\"*\207" [(#0) #s(transient-prefix #s(transient-prefix eieio--unbound gptel-system-prompt eieio--unbound eieio--unbound eieio--unbound eieio--unbound nil nil nil 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) gptel-system-prompt 7 eieio--unbound nil eieio--unbound t nil (nil) 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) #s(transient-suffix #s(transient-column #s(transient-columns nil 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#5 #s(transient-column #6 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#s(gptel--scope #8 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "=" gptel--infix-variable-scope t "  %k %d %v" #("Scope" 0 5 (face transient-inactive-argument)) nil nil nil "scope" eieio--unbound nil eieio--unbound nil nil t nil nil transient-lisp-variable--reader nil nil gptel--set-buffer-locally set eieio--unbound nil "buffer" "global")) nil nil nil nil eieio--unbound)) nil gptel-system-prompt--format nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#4) nil nil nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "s" gptel--suffix-system-message transient--do-exit " %k   %d" "Set or edit system message" nil nil nil) gptel--suffix-system-message debugger make-closure #[0 "\303\301\304\"\211\203\20\0\305\306!\210\211\302!\210\210\3029\203(\0\307\302K\300\242\"\211\302K=\204'\0\302\1M\210\210\310\301\304\311#\207" [V0 V1 V2 eieio-oref unwind-suffix transient--debug unwind-command advice--remove-function eieio-oset nil] 4] transient--exit-and-debug eieio-oref parent advice advice* apply] 8 "\n\n(fn FN &rest ARGS)" nil] '#[257 "\305C\306\307\2\300\301\303%\216\310\34\302\205\24\0\311\302\312\"\211\205#\0\311\302\313\"\206#\0\311\1\313\"\211\203.\0\211\314\5\"\2021\0\314\4!)\266\202\1\315\240)\210\207" [(#0) #s(transient-prefix #s(transient-prefix eieio--unbound gptel-system-prompt eieio--unbound eieio--unbound eieio--unbound eieio--unbound nil nil nil 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) gptel-system-prompt 7 eieio--unbound nil eieio--unbound t nil (nil) 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) #s(transient-suffix #s(transient-column #s(transient-columns nil 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#5 #s(transient-column #6 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#s(gptel--scope #8 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "=" gptel--infix-variable-scope t "  %k %d %v" #("Scope" 0 5 (face transient-inactive-argument)) nil nil nil "scope" eieio--unbound nil eieio--unbound nil nil t nil nil transient-lisp-variable--reader nil nil gptel--set-buffer-locally set eieio--unbound nil "buffer" "global")) nil nil nil nil eieio--unbound)) nil gptel-system-prompt--format nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#4) nil nil nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "s" gptel--suffix-system-message transient--do-exit " %k   %d" "Set or edit system message" nil nil nil) gptel--suffix-system-message debugger t make-closure #[0 "\300\242\2052\0\304\302\305\"\211\203\25\0\306\307!\210\211\303!\210\210\3039\203-\0\310\303K\301\242\"\211\303K=\204,\0\303\1M\210\210\311\302\305\312#\207" [V0 V1 V2 V3 eieio-oref unwind-suffix transient--debug unwind-interactive advice--remove-function eieio-oset nil] 4] transient--exit-and-debug eieio-oref parent advice* advice-eval-interactive-spec nil] 8 "\n\n(fn SPEC)"] apply called-interactively-p any funcall-interactively funcall] 5 cconv--interactive-helper](#<subr gptel--suffix-system-message> nil)
  apply(#[128 "\302\303\304!\203\13\0\305\202\f\0\306\300\3#\207" [#[385 "\305\306\300\301\303$\216\307\34\302\205\21\0\310\302\311\"\211\205.\0\310\302\312\"\206.\0\310\302\313\"\206.\0\310\1\312\"\206.\0\310\1\313\"\211\203:\0\314\1\5\5#\202>\0\314\4\4\"*\207" [(#0) #s(transient-prefix #s(transient-prefix eieio--unbound gptel-system-prompt eieio--unbound eieio--unbound eieio--unbound eieio--unbound nil nil nil 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) gptel-system-prompt 7 eieio--unbound nil eieio--unbound t nil (nil) 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) #s(transient-suffix #s(transient-column #s(transient-columns nil 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#5 #s(transient-column #6 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil ... nil nil nil nil eieio--unbound)) nil gptel-system-prompt--format nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#4) nil nil nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "s" gptel--suffix-system-message transient--do-exit " %k   %d" "Set or edit system message" nil nil nil) gptel--suffix-system-message debugger make-closure #[0 "\303\301\304\"\211\203\20\0\305\306!\210\211\302!\210\210\3029\203(\0\307\302K\300\242\"\211\302K=\204'\0\302\1M\210\210\310\301\304\311#\207" [V0 V1 V2 eieio-oref unwind-suffix transient--debug unwind-command advice--remove-function eieio-oset nil] 4] transient--exit-and-debug eieio-oref parent advice advice* apply] 8 "\n\n(fn FN &rest ARGS)" nil] '#[257 "\305C\306\307\2\300\301\303%\216\310\34\302\205\24\0\311\302\312\"\211\205#\0\311\302\313\"\206#\0\311\1\313\"\211\203.\0\211\314\5\"\2021\0\314\4!)\266\202\1\315\240)\210\207" [(#0) #s(transient-prefix #s(transient-prefix eieio--unbound gptel-system-prompt eieio--unbound eieio--unbound eieio--unbound eieio--unbound nil nil nil 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) gptel-system-prompt 7 eieio--unbound nil eieio--unbound t nil (nil) 0 nil nil nil nil nil nil eieio--unbound nil nil nil eieio--unbound nil eieio--unbound nil nil nil) #s(transient-suffix #s(transient-column #s(transient-columns nil 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#5 #s(transient-column #6 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil ... nil nil nil nil eieio--unbound)) nil gptel-system-prompt--format nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil (#4) nil nil nil nil eieio--unbound) 1 nil nil nil nil nil nil nil nil nil transient-inapt-suffix nil nil nil nil nil nil nil nil nil nil "s" gptel--suffix-system-message transient--do-exit " %k   %d" "Set or edit system message" nil nil nil) gptel--suffix-system-message debugger t make-closure #[0 "\300\242\2052\0\304\302\305\"\211\203\25\0\306\307!\210\211\303!\210\210\3039\203-\0\310\303K\301\242\"\211\303K=\204,\0\303\1M\210\210\311\302\305\312#\207" [V0 V1 V2 V3 eieio-oref unwind-suffix transient--debug unwind-interactive advice--remove-function eieio-oset nil] 4] transient--exit-and-debug eieio-oref parent advice* advice-eval-interactive-spec nil] 8 "\n\n(fn SPEC)"] apply called-interactively-p any funcall-interactively funcall] 5 cconv--interactive-helper] #<subr gptel--suffix-system-message> nil)
  gptel--suffix-system-message(nil)
  funcall-interactively(gptel--suffix-system-message nil)
  command-execute(gptel--suffix-system-message)
```