### PR TITLE
gptel: preserve global values within `gptel-with-preset`

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -3800,9 +3800,13 @@ from a gptel preset applied.
 NAME is the name of a preset, or a spec (plist) of the form
  (:KEY1 VAL1 :KEY2 VAL2 ...).  It must be quoted."
   (declare (indent 1))
-  `(cl-progv (gptel--preset-syms ,name) nil
-    (gptel--apply-preset ,name)
-    ,@body))
+  ;; Use a unique uninterned symbol so that our let-binding doesn't
+  ;; interfere with symbols in the body.
+  (let ((preset-syms (gensym "gptel--preset-syms")))
+    `(let ((,preset-syms (gptel--preset-syms ,name)))
+       (cl-progv ,preset-syms (mapcar #'symbol-value ,preset-syms)
+         (gptel--apply-preset ,name)
+         ,@body))))
 
 ;;;; Presets in-buffer UI
 (defun gptel--transform-apply-preset (_fsm)


### PR DESCRIPTION
Instead of binding symbols targeted by a preset to `nil` initially, bind them to their real current value.

Currently this change is only relevant for presets using `:tools` with the `:append` keyword (since all other relevant values will simply be overridden when applying the preset). If some version of dynamic/functional presets ends up getting merged, this would be relevant for a wider range of cases.

Here's a snippet that can be run to demonstrate the difference:

``` emacs-lisp
(progn
  (gptel-make-tool
   :name "global_tool"
   :function (lambda ())
   :description "global tool"
   :args nil)
  (gptel-make-tool
   :name "preset_tool"
   :function (lambda ())
   :description "preset tool"
   :args nil)

  (let ((gptel-tools (list (gptel-get-tool "global_tool"))))
    (message "Outside gptel-with-preset: %s"
             (mapcar #'gptel-tool-name gptel-tools))
    (gptel-with-preset
     '(:tools (:append "preset_tool"))
     (message "Inside gptel-with-preset: %s"
              (mapcar #'gptel-tool-name gptel-tools)))))
```

Output without this change:

``` text
Outside gptel-with-preset: (global_tool)
Inside gptel-with-preset: (preset_tool)
```

Output after applying this change:

``` text
Outside gptel-with-preset: (global_tool)
Inside gptel-with-preset: (global_tool preset_tool)
```