### PR TITLE
gptel-bedrock: AWS_BEARER_TOKEN_BEDROCK support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,11 @@
 - gptel now handles Ollama models that return both reasoning content
   and tool calls in a single request.
 
+- ~gptel-make-bedrock~ now checks for the ~AWS_BEARER_TOKEN_BEDROCK~ environment
+  variable parameter and uses it for Bedrock API key based authentication if
+  present. See
+  https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html.
+
 * 0.9.8.5 2025-06-11
 
 ** Breaking changes

--- a/README.org
+++ b/README.org
@@ -1060,10 +1060,10 @@ Register a backend with
   :model-region 'apac)
 #+end_src
 
-The Bedrock backend gets your AWS credentials from the environment variables. It expects to find either
+The Bedrock backend gets your AWS credentials from the environment variables. If ~AWS_BEARER_TOKEN_BEDROCK~ is present, it uses the bearer token. Otherwise it expects to find either
 ~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~, ~AWS_SESSION_TOKEN~ (optional), or if present, can use ~AWS_PROFILE~ to get these directly from the ~aws~ cli.
 
-NOTE: The Bedrock backend needs curl >= 8.5 in order for the sigv4 signing to work properly,
+NOTE: Unless ~AWS_BEARER_TOKEN_BEDROCK~ token is used, the Bedrock backend needs curl >= 8.9 in order for the sigv4 signing to work properly,
 https://github.com/curl/curl/issues/11794
 
 An error will be signalled if ~gptel-curl~ is ~NIL~.


### PR DESCRIPTION
AWS has introduced Bearer token based authentication for Bedrock https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html Bearer token based authentication only requires the `Authorization: Bearer` header and does not need the sigv4 signing and thus removes the current dependency of the Bedrock backend on curl >= 8.9.