### PR TITLE
Fix(curl): Prevent hang on successful empty response

### DIFF
--- a/gptel-curl.el
+++ b/gptel-curl.el
@@ -423,7 +423,11 @@ PROCESS and _STATUS are process parameters."
             (when-let* ((reasoning (plist-get proc-info :reasoning))
                         ((stringp reasoning)))
               (funcall proc-callback (cons 'reasoning reasoning) proc-info))))
-        (when (or response (not (member http-status '("200" "100"))))
+        ;; The original condition failed to call the callback when a request
+        ;; succeeded (HTTP 200) but had an empty/malformed response body.
+        ;; This new condition ensures the callback always fires for any completed
+        ;; process, preventing a silent hang.
+        (when http-status
           (with-demoted-errors "gptel callback error: %S"
             (funcall proc-callback response proc-info))))
       (gptel--fsm-transition fsm))      ;TYPE -> next


### PR DESCRIPTION
Hello, while developing an extension that uses the gptel API, I encountered an intermittent bug where a request callback would occasionally fail to trigger. This left my script hanging, as it never received the final signal for a completed request.

I debugged the issue with the help of an AI, and it identified the root cause within gptel's handling of non-streaming curl requests. Here's a summary of the findings:

A request would hang if the server returned a successful HTTP status (200 OK) but with an empty or malformed JSON body. The internal sentinel function failed to call the final callback because its conditional logic required a non-nil response body on a successful request.

This patch fixes the problem by making the callback trigger dependent only on a completed HTTP status. This change ensures the client is always notified when a request finishes, preventing the silent hang.