### PR TITLE
Add gpt-5-mini to github copilot

### DIFF
--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -55,6 +55,14 @@
      :input-cost 1.25
      :output-cost 10
      :cutoff-date "2024-09")
+    (gpt-5-mini
+     :description "GPT-5 mini is a faster, more cost-efficient version of GPT-5"
+     :capabilities (media tool-use json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 128
+     :input-cost 0.25
+     :output-cost 2
+     :cutoff-date "2024-05")
     (o1
      :description "Reasoning model designed to solve hard problems across domains"
      :capabilities (reasoning tool-use)


### PR DESCRIPTION
This adds gpt-5-mini support to github copilot.

https://github.blog/changelog/2025-08-13-gpt-5-mini-now-available-in-github-copilot-in-public-preview/
https://llm-stats.com/models/compare/gpt-5-mini-2025-08-07-vs-gpt-5-2025-08-07