### PR TITLE
AWS bedrock-update

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -66,6 +66,11 @@
   context.  This setting can be controlled via the user option
   ~gptel-context-restrict-to-project-files~.
 
+- ~gptel-make-bedrock~ now checks for the ~AWS_BEARER_TOKEN_BEDROCK~ environment
+  variable parameter and uses it for Bedrock API key based authentication if
+  present. See
+  https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html.
+
 * 0.9.9 2025-08-02
 
 ** Breaking changes

--- a/NEWS
+++ b/NEWS
@@ -49,6 +49,14 @@
   For logistical reasons, the =gptel-request= library will continue to
   be shipped with =gptel=.
 
+- New user option ~gptel-context~: This variable can be used to specify
+  additional context sources for gptel queries, usually files or
+  buffers.  It serves the longstanding requests of enabling buffer-local
+  context specification, as well as context specification in gptel
+  presets and programmatic gptel use.  Each entry is a file path or a
+  buffer object, but other kinds of specification are possible.  See its
+  documentation for details.
+
 - ~gptel-mcp-connect~ can now start MCP servers synchronously.  This
   is useful for scripting purposes, when MCP tools need to be
   available before performing other actions.  One common use is

--- a/README.org
+++ b/README.org
@@ -1114,6 +1114,7 @@ Register a backend with
 #+end_src
 
 AWS has numerous credential provisions; we follow this order precedence,
+- (argument) ~:aws-bearer-token~
 - (env. variable) ~AWS_BEARER_TOKEN_BEDROCK~
 - (argument) ~:aws-profile~
   If this option is specified, the Bedrock-backend uses the shared AWS config and credentials files to obtain credentials based on the AWS Profile selected. If ~:aws-profile~ is set to the keyword ~:static~, the IAM credentials are imported without a profile argument.

--- a/README.org
+++ b/README.org
@@ -1113,9 +1113,13 @@ Register a backend with
   :model-region 'apac)
 #+end_src
 
-When the ~:aws-profile~ option is specified, the Bedrock backend uses the shared AWS config and credentials files to obtain credentials based on the AWS Profile selected. Alternatively ~AWS_PROFILE~ environment variable can be used to provide the profile name. If ~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~ and ~AWS_SESSION_TOKEN~ environment variables are provided the profile will be ignored.
+AWS has numerous credential provisions; we follow this order precedence,
+- (argument) ~:aws-profile~
+  If this option is specified, the Bedrock-backend uses the shared AWS config and credentials files to obtain credentials based on the AWS Profile selected. If ~:aws-profile~ is set to the keyword ~:static~, the IAM credentials are imported without a profile argument.
+- (env. varible) ~AWS_PROFILE~
+- (env. varible) ~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~ and ~AWS_SESSION_TOKEN~
 
-NOTE: The Bedrock backend needs curl >= 8.5 in order for the sigv4 signing to work properly,
+NOTE: The Bedrock backend needs curl >= 8.9 in order for the sigv4 signing to work properly,
 https://github.com/curl/curl/issues/11794
 
 An error will be signalled if ~gptel-curl~ is ~NIL~.

--- a/README.org
+++ b/README.org
@@ -1114,12 +1114,13 @@ Register a backend with
 #+end_src
 
 AWS has numerous credential provisions; we follow this order precedence,
+- (env. variable) ~AWS_BEARER_TOKEN_BEDROCK~
 - (argument) ~:aws-profile~
   If this option is specified, the Bedrock-backend uses the shared AWS config and credentials files to obtain credentials based on the AWS Profile selected. If ~:aws-profile~ is set to the keyword ~:static~, the IAM credentials are imported without a profile argument.
 - (env. varible) ~AWS_PROFILE~
 - (env. varible) ~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~ and ~AWS_SESSION_TOKEN~
 
-NOTE: The Bedrock backend needs curl >= 8.9 in order for the sigv4 signing to work properly,
+NOTE: Unless ~AWS_BEARER_TOKEN_BEDROCK~ token is used, the Bedrock backend needs curl >= 8.9 in order for the sigv4 signing to work properly,
 https://github.com/curl/curl/issues/11794
 
 An error will be signalled if ~gptel-curl~ is ~NIL~.

--- a/README.org
+++ b/README.org
@@ -1113,8 +1113,7 @@ Register a backend with
   :model-region 'apac)
 #+end_src
 
-The Bedrock backend gets your AWS credentials from the environment variables. It expects to find either
-~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~, ~AWS_SESSION_TOKEN~ (optional), or if present, can use ~AWS_PROFILE~ to get these directly from the ~aws~ cli.
+When the ~:aws-profile~ option is specified, the Bedrock backend uses the shared AWS config and credentials files to obtain credentials based on the AWS Profile selected. Alternatively ~AWS_PROFILE~ environment variable can be used to provide the profile name. If ~AWS_ACCESS_KEY_ID~, ~AWS_SECRET_ACCESS_KEY~ and ~AWS_SESSION_TOKEN~ environment variables are provided the profile will be ignored.
 
 NOTE: The Bedrock backend needs curl >= 8.5 in order for the sigv4 signing to work properly,
 https://github.com/curl/curl/issues/11794
@@ -1134,6 +1133,8 @@ The above code makes the backend available to select.  If you want it to be the 
       (gptel-make-bedrock "AWS"
         ;; optionally enable streaming
         :stream t
+        ;; optionally specify the aws profile
+        ;; :profile
         :region "ap-northeast-1"
         ;; subset of gptel--bedrock-models
         :models '(claude-sonnet-4-20250514)

--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -483,7 +483,7 @@ format."
 (cl-defmethod gptel--inject-media ((_backend gptel-anthropic) prompts)
   "Wrap the first user prompt in PROMPTS with included media files.
 
-Media files, if present, are placed in `gptel-context--alist'."
+Media files, if present, are placed in `gptel-context'."
   (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
                 (vconcat
@@ -494,7 +494,7 @@ Media files, if present, are placed in `gptel-context--alist'."
                    (t current))))
         (plist-get (car prompts) :content))))
 
-;; (if-let* ((context-string (gptel-context--string gptel-context--alist)))
+;; (if-let* ((context-string (gptel-context--string gptel-context)))
 ;;     (cl-callf (lambda (previous)
 ;;                 (cl-typecase previous
 ;;                   (string (concat context-string previous))

--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -480,32 +480,19 @@ format."
    into parts-array
    finally return (vconcat parts-array)))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-anthropic) prompts
-                                       &optional inject-media)
-  "Wrap the last user prompt in PROMPTS with the context string.
+(cl-defmethod gptel--inject-media ((_backend gptel-anthropic) prompts)
+  "Wrap the first user prompt in PROMPTS with included media files.
 
-If INJECT-MEDIA is non-nil wrap it with base64-encoded media
-files in the context."
-  (if inject-media
-      ;; Wrap the first user prompt with included media files/contexts
-      (when-let* ((media-list (gptel-context--collect-media)))
-        (cl-callf (lambda (current)
-                    (vconcat
-                     (gptel--anthropic-parse-multipart media-list)
-                     (cl-typecase current
-                       (string `((:type "text" :text ,current)))
-                       (vector current)
-                       (t current))))
-            (plist-get (car prompts) :content)))
-    ;; Wrap the last user prompt with included text contexts
+Media files, if present, are placed in `gptel-context--alist'."
+  (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
-                (cl-etypecase current
-                  (string (gptel-context--wrap current))
-                  (vector (if-let* ((wrapped (gptel-context--wrap nil)))
-                              (vconcat `((:type "text" :text ,wrapped))
-                                       current)
-                            current))))
-        (plist-get (car (last prompts)) :content))))
+                (vconcat
+                 (gptel--anthropic-parse-multipart media-list)
+                 (cl-typecase current
+                   (string `((:type "text" :text ,current)))
+                   (vector current)
+                   (t current))))
+        (plist-get (car prompts) :content))))
 
 ;; (if-let* ((context-string (gptel-context--string gptel-context--alist)))
 ;;     (cl-callf (lambda (previous)

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -139,7 +139,7 @@ Assumes this is a conversation with alternating roles."
 (cl-defmethod gptel--inject-media ((_backend gptel-bedrock) prompts)
   "Wrap the first user prompt in PROMPTS with included media files.
 
-Media files, if present, are placed in `gptel-context--alist'."
+Media files, if present, are placed in `gptel-context'."
   (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf2 vconcat (gptel-bedrock--parse-multipart media-list)
                (plist-get (car prompts) :content))))

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -136,31 +136,13 @@ Assumes this is a conversation with alternating roles."
            (list :role (if role "user" "assistant")
                  :content `[(:text ,text)])))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-bedrock) prompts &optional inject-media)
-  "Inject context into a conversation.
+(cl-defmethod gptel--inject-media ((_backend gptel-bedrock) prompts)
+  "Wrap the first user prompt in PROMPTS with included media files.
 
-PROMPTS is list of prompt objects.  If INJECT-MEDIA is non-nil
-inject the media files from context into the beginning of the
-conversation; otherwise inject the context into the last prompt."
-  (if inject-media
-      (gptel-bedrock--inject-media-context prompts)
-    (gptel-bedrock--inject-text-context prompts)))
-
-(defun gptel-bedrock--inject-media-context (prompts)
-  "Inject media files from context into a conversation.
-Media files will be added at the beginning of the conversation.
-PROMPTS should be a non-empty list of prompt objects."
+Media files, if present, are placed in `gptel-context--alist'."
   (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf2 vconcat (gptel-bedrock--parse-multipart media-list)
                (plist-get (car prompts) :content))))
-
-(defun gptel-bedrock--inject-text-context (prompts)
-  "Inject text context into the last prompt object from a conversation.
-PROMPTS should be a non-empty list of prompt objects."
-  (cl-assert prompts nil "Expected a non-empty list of prompts")
-  (when-let* ((wrapped (gptel-context--wrap nil)))
-    (cl-callf2 vconcat `[(:text ,wrapped)]
-               (plist-get (car (last prompts)) :content))))
 
 (defvar-local gptel-bedrock--stream-cursor nil
   "Marker to indicate last point parsed.")

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -504,8 +504,15 @@ Non-nil CLEAR-CACHE will refresh credentials."
        (gptel-bedrock--fetch-aws-profile-credentials profile t))
       (t (user-error "AWS credentials expired for profile: %s" profile)))))
 
-(defun gptel-bedrock--get-credentials ()
+(defun gptel-bedrock--get-credentials (profile)
   "Return the AWS credentials to use for the request.
+
+If credentials are not available based on the AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN environment variables,
+aws configure export-credentials is used to obtain credentials.
+PROFILE specifies the AWS profile to use for retrieving
+credentials.  If PROFILE is unset, AWS_PROFILE environment
+variable is used.
 
 Returns a list of 2-3 elements, depending on whether a session
 token is needed, with this form: (AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
@@ -515,11 +522,11 @@ Convenient to use with `cl-multiple-value-bind'"
   (let ((key-id (getenv "AWS_ACCESS_KEY_ID"))
         (secret-key (getenv "AWS_SECRET_ACCESS_KEY"))
         (token (getenv "AWS_SESSION_TOKEN"))
-	(profile (getenv "AWS_PROFILE")))
+	(profile (or profile (getenv "AWS_PROFILE"))))
     (cond
       ((and key-id secret-key) (cl-values key-id secret-key token))
       ((and profile) (gptel-bedrock--fetch-aws-profile-credentials profile))
-      (t (user-error "Missing AWS credentials; currently only environment variables are supported")))))
+      (t (user-error "Missing AWS credentials; provide them either via environment variables or specify PROFILE when calling gptel-make-bedrock")))))
 
 (defvar gptel-bedrock--model-ids
   ;; https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
@@ -568,10 +575,12 @@ REGION is one of apac, eu or us."
    (or (alist-get model gptel-bedrock--model-ids nil nil #'eq)
        (error "Unknown Bedrock model: %s" model))))
 
-(defun gptel-bedrock--curl-args (region)
-  "Generate the curl arguments to get a bedrock request signed for use in REGION."
+(defun gptel-bedrock--curl-args (region profile)
+  "Generate the curl arguments to get a bedrock request signed for use in REGION.
+
+PROFILE specifies the aws profile to use for aws configure export-credentials."
   ;; https://curl.se/docs/manpage.html#--aws-sigv4
-  (cl-multiple-value-bind (key-id secret token) (gptel-bedrock--get-credentials)
+  (cl-multiple-value-bind (key-id secret token) (gptel-bedrock--get-credentials profile)
     (nconc
      (list
       "--user" (format "%s:%s" key-id secret)
@@ -596,6 +605,7 @@ REGION is one of apac, eu or us."
           (models gptel--bedrock-models)
 	  (model-region nil)
           stream curl-args request-params
+	  (aws-profile nil)
           (protocol "https"))
   "Register an AWS Bedrock backend for gptel with NAME.
 
@@ -604,6 +614,7 @@ Keyword arguments:
 REGION - AWS region name (e.g. \"us-east-1\")
 MODELS - The list of models supported by this backend
 MODEL-REGION - one of apac, eu, us or nil
+AWS-PROFILE - the aws profile to use for aws configure export-credentials
 CURL-ARGS - additional curl args
 STREAM - Whether to use streaming responses or not.
 REQUEST-PARAMS - a plist of additional HTTP request
@@ -619,12 +630,12 @@ parameters (as plist keys) and values supported by the API."
            :host host
            :header nil           ; x-amz-security-token is set in curl-args if needed
            :models (gptel--process-models models)
-	   :model-region model-region
+           :model-region model-region
            :protocol protocol
            :endpoint "" ; Url is dynamically constructed based on other args
            :stream stream
            :coding-system (and stream 'binary)
-           :curl-args (lambda () (append curl-args (gptel-bedrock--curl-args region)))
+           :curl-args (lambda () (append curl-args (gptel-bedrock--curl-args region aws-profile)))
            :request-params request-params
            :url
            (lambda ()

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -481,7 +481,8 @@ conversation."
 (defun gptel-bedrock--fetch-aws-profile-credentials (profile &optional clear-cache)
   "Fetch & cache AWS credentials for PROFILE using aws-cli.
 
-If PROFILE is the keyword ':static', then it fetches IAM credentials from the aws-cli without any profile argument.
+If PROFILE is the keyword ':static', then it fetches IAM credentials
+from the aws-cli without any profile argument.
 
 Non-nil CLEAR-CACHE will refresh credentials."
   (let* ((creds-json
@@ -580,7 +581,8 @@ REGION is one of apac, eu or us."
 (defun gptel-bedrock--curl-args (region profile bearer-token)
   "Generate the curl arguments to get a bedrock request signed for use in REGION.
 
-PROFILE specifies the aws profile to use for aws configure export-credentials."
+PROFILE specifies the aws profile to use for aws configure
+export-credentials.  BEARER-TOKEN is the token used for authentication."
   (let ((bearer-token (or bearer-token (getenv "AWS_BEARER_TOKEN_BEDROCK")))
         (output-args (unless (memq system-type '(windows-nt ms-dos))
                        '("--output" "/dev/stdout"))))

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -581,17 +581,20 @@ REGION is one of apac, eu or us."
   "Generate the curl arguments to get a bedrock request signed for use in REGION.
 
 PROFILE specifies the aws profile to use for aws configure export-credentials."
-  ;; https://curl.se/docs/manpage.html#--aws-sigv4
-  (cl-multiple-value-bind (key-id secret token) (gptel-bedrock--get-credentials profile)
-    (nconc
-     (list
-      "--user" (format "%s:%s" key-id secret)
-      "--aws-sigv4" (format "aws:amz:%s:bedrock" region))
-     (unless (memq system-type '(windows-nt ms-dos))
-       ;; Without this curl swallows the output
-       (list "--output" "/dev/stdout"))
-     (when token
-       (list (format "-Hx-amz-security-token: %s" token))))))
+  (let ((bearer-token (getenv "AWS_BEARER_TOKEN_BEDROCK"))
+        (output-args (unless (memq system-type '(windows-nt ms-dos))
+                       '("--output" "/dev/stdout"))))
+    (if bearer-token
+        (append
+         (list "-H" (format "Authorization: Bearer %s" bearer-token))
+         output-args)
+      (cl-multiple-value-bind (key-id secret token) (gptel-bedrock--get-credentials profile)
+        (append
+         (list "--user" (format "%s:%s" key-id secret)
+               "--aws-sigv4" (format "aws:amz:%s:bedrock" region))
+         output-args
+         (when token (list "-H" (format "x-amz-security-token: %s" token))))))))
+
 
 (defun gptel-bedrock--curl-version ()
   "Check Curl version required for gptel-bedrock."
@@ -622,9 +625,10 @@ STREAM - Whether to use streaming responses or not.
 REQUEST-PARAMS - a plist of additional HTTP request
 parameters (as plist keys) and values supported by the API."
   (declare (indent 1))
-  (unless (and gptel-use-curl (version<= "8.9" (gptel-bedrock--curl-version)))
-    (error "Bedrock-backend requires curl >= 8.9, but gptel-use-curl := %s, curl-version := %s"
-           gptel-use-curl (gptel-bedrock--curl-version)))
+  (unless (getenv "AWS_BEARER_TOKEN_BEDROCK")
+    (unless (and gptel-use-curl (version<= "8.9" (gptel-bedrock--curl-version)))
+      (error "Bedrock-backend requires curl >= 8.9, but gptel-use-curl := %s, curl-version := %s"
+             gptel-use-curl (gptel-bedrock--curl-version))))
   (let ((host (format "bedrock-runtime.%s.amazonaws.com" region)))
     (setf (alist-get name gptel--known-backends nil nil #'equal)
           (gptel--make-bedrock

--- a/gptel-context.el
+++ b/gptel-context.el
@@ -147,8 +147,8 @@ context."
    ;; A region is selected.
    ((use-region-p)
     (gptel-context--add-region (current-buffer)
-                                  (region-beginning)
-                                  (region-end))
+                               (region-beginning)
+                               (region-end))
     (deactivate-mark)
     (message "Current region added as context."))
    ;; If in dired
@@ -170,9 +170,9 @@ context."
 	 (buffer-file-name)
 	 (not (gptel-context--skip-p (buffer-file-name))))
     (funcall (if (and arg (< (prefix-numeric-value arg) 0))
-              #'gptel-context-remove
-              #'gptel-context-add-file)
-          (buffer-file-name)))
+                 #'gptel-context-remove
+               #'gptel-context-add-file)
+             (buffer-file-name)))
    ;; No region is selected, and ARG is positive.
    ((and arg (> (prefix-numeric-value arg) 0))
     (let* ((buffer-name (read-buffer "Choose buffer to add as context: "
@@ -247,7 +247,7 @@ readable as text."
     (run-at-time
      0 nil
      (lambda () (setq gptel-context--reset-cache nil
-                 gptel-context--project-files nil))))
+                      gptel-context--project-files nil))))
   (cond ((file-directory-p path)
          (gptel-context--add-directory path 'add))
         ((gptel-context--skip-p path)
@@ -361,7 +361,7 @@ DATA-BUF is the buffer where the request prompt is constructed."
   (if (= (car (func-arity gptel-context-string-function)) 2)
       (funcall gptel-context-string-function
                (lambda (c) (with-current-buffer data-buf
-                        (gptel-context--wrap-in-buffer c))
+                             (gptel-context--wrap-in-buffer c))
                  (funcall callback))
                (gptel-context--collect))
     (with-current-buffer data-buf
@@ -426,7 +426,7 @@ the beginning and end."
         (gptel-context--in-region buffer region-beginning region-end))
   (prog1 (with-current-buffer buffer
            (gptel-context--make-overlay region-beginning region-end advance))
-      (message "Region added to context buffer.")))
+    (message "Region added to context buffer.")))
 
 (defun gptel-context--in-region (buffer start end)
   "Return the list of context overlays in the given region, if any, in BUFFER.
@@ -470,38 +470,38 @@ Ignore overlays, buffers and files that are not live or readable."
   "Insert at point a context string from all OVERLAYS in BUFFER.
 
 If OVERLAYS is nil add the entire buffer text."
-    (let ((is-top-snippet t)
-          (previous-line 1))
-      (insert (format "In buffer `%s`:" (buffer-name buffer))
-              "\n\n```" (gptel--strip-mode-suffix (buffer-local-value
-                                                   'major-mode buffer))
-              "\n")
-      (if (not overlays)
-          (insert-buffer-substring-no-properties buffer)
-        (dolist (context overlays)
-          (let* ((start (overlay-start context))
-                 (end (overlay-end context)))
-            (let (lineno column)
-              (with-current-buffer buffer
-                (without-restriction
-                  (setq lineno (line-number-at-pos start t)
-                        column (save-excursion (goto-char start) (current-column)))))
-              ;; We do not need to insert a line number indicator if we have two regions
-              ;; on the same line, because the previous region should have already put the
-              ;; indicator.
-              (unless (= previous-line lineno)
-                (unless (= lineno 1)
-                  (unless is-top-snippet (insert "\n"))
-                  (insert (format "... (Line %d)\n" lineno))))
-              (setq previous-line lineno)
-              (unless (zerop column) (insert " ..."))
-              (if is-top-snippet
-                  (setq is-top-snippet nil)
-                (unless (= previous-line lineno) (insert "\n"))))
-            (insert-buffer-substring-no-properties buffer start end)))
-        (unless (>= (overlay-end (car (last overlays))) (point-max))
-          (insert "\n...")))
-      (insert "\n```")))
+  (let ((is-top-snippet t)
+        (previous-line 1))
+    (insert (format "In buffer `%s`:" (buffer-name buffer))
+            "\n\n```" (gptel--strip-mode-suffix (buffer-local-value
+                                                 'major-mode buffer))
+            "\n")
+    (if (not overlays)
+        (insert-buffer-substring-no-properties buffer)
+      (dolist (context overlays)
+        (let* ((start (overlay-start context))
+               (end (overlay-end context)))
+          (let (lineno column)
+            (with-current-buffer buffer
+              (without-restriction
+                (setq lineno (line-number-at-pos start t)
+                      column (save-excursion (goto-char start) (current-column)))))
+            ;; We do not need to insert a line number indicator if we have two regions
+            ;; on the same line, because the previous region should have already put the
+            ;; indicator.
+            (unless (= previous-line lineno)
+              (unless (= lineno 1)
+                (unless is-top-snippet (insert "\n"))
+                (insert (format "... (Line %d)\n" lineno))))
+            (setq previous-line lineno)
+            (unless (zerop column) (insert " ..."))
+            (if is-top-snippet
+                (setq is-top-snippet nil)
+              (unless (= previous-line lineno) (insert "\n"))))
+          (insert-buffer-substring-no-properties buffer start end)))
+      (unless (>= (overlay-end (car (last overlays))) (point-max))
+        (insert "\n...")))
+    (insert "\n```")))
 
 (defun gptel-context--string (context-alist)
   "Format the aggregated gptel context as annotated markdown fragments.
@@ -524,8 +524,8 @@ context overlays, see `gptel-context'."
                (goto-char (point-min))
                (insert "Request context:\n\n"))
              finally return
-              (and (> (buffer-size) 0)
-                   (buffer-string)))))
+             (and (> (buffer-size) 0)
+                  (buffer-string)))))
 
 ;;; Major mode for context inspection buffers
 (defvar-keymap gptel-context-buffer-mode-map

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -361,7 +361,7 @@ format."
 (cl-defmethod gptel--inject-media ((_backend gptel-gemini) prompts)
   "Wrap the first user prompt in PROMPTS with included media files.
 
-Media files, if present, are placed in `gptel-context--alist'."
+Media files, if present, are placed in `gptel-context'."
   (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
                 (vconcat (gptel--gemini-parse-multipart media-list)

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -358,25 +358,15 @@ format."
    into parts-array
    finally return (vconcat parts-array)))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-gemini) prompts
-                                       &optional inject-media)
-  "Wrap the last user prompt in PROMPTS with the context string.
+(cl-defmethod gptel--inject-media ((_backend gptel-gemini) prompts)
+  "Wrap the first user prompt in PROMPTS with included media files.
 
-If INJECT-MEDIA is non-nil wrap it with base64-encoded media
-files in the context."
-  (if inject-media
-      ;; Wrap the first user prompt with included media files/contexts
-      (when-let* ((media-list (gptel-context--collect-media)))
-        (cl-callf (lambda (current)
-                    (vconcat (gptel--gemini-parse-multipart media-list)
-                             current))
-            (plist-get (car prompts) :parts)))
-    ;; Wrap the last user prompt with included text contexts
+Media files, if present, are placed in `gptel-context--alist'."
+  (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
-                (if-let* ((wrapped (gptel-context--wrap nil)))
-                    (vconcat `((:text ,wrapped)) current)
-                  current))
-        (plist-get (car (last prompts)) :parts))))
+                (vconcat (gptel--gemini-parse-multipart media-list)
+                         current))
+        (plist-get (car prompts) :parts))))
 
 (defconst gptel--gemini-models
   '((gemini-pro-latest

--- a/gptel-kagi.el
+++ b/gptel-kagi.el
@@ -117,15 +117,6 @@
                      ""))))
           prompts)))))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-kagi) prompts)
-  (cond
-   ((plist-get prompts :url)
-    (message "Ignoring gptel context for URL summary request."))
-   ((plist-get prompts :query)
-    (cl-callf gptel-context--wrap (plist-get prompts :query)))
-   ((plist-get prompts :text)
-    (cl-callf gptel-context--wrap (plist-get prompts :text)))))
-
 ;;;###autoload
 (cl-defun gptel-make-kagi
     (name &key curl-args stream key
@@ -187,7 +178,7 @@ Example:
     (prog1 backend
       (setf (alist-get name gptel--known-backends
                        nil nil #'equal)
-                  backend))))
+            backend))))
 
 (provide 'gptel-kagi)
 ;;; gptel-kagi.el ends here

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -242,22 +242,16 @@ format."
    `(,@(and text-array  (list :content (mapconcat #'identity text-array " ")))
      ,@(and media-array (list :images  (vconcat media-array))))))
 
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-ollama) prompts
-                                       &optional inject-media)
-  "Wrap the last user prompt in PROMPTS with the context string.
+(cl-defmethod gptel--inject-media ((_backend gptel-ollama) prompts)
+  "Wrap the first user prompt in PROMPTS with included media files.
 
-If INJECT-MEDIA is non-nil wrap it with base64-encoded media
-files in the context."
-  (if inject-media
-      ;; Wrap the first user prompt with included media files/contexts
-      (when-let* ((media-list (gptel-context--collect-media))
-                  (media-processed (gptel--ollama-parse-multipart media-list)))
-        (cl-callf (lambda (images)
-                    (vconcat (plist-get media-processed :images)
-                             images))
-            (plist-get (car prompts) :images)))
-    ;; Wrap the last user prompt with included text contexts
-    (cl-callf gptel-context--wrap (plist-get (car (last prompts)) :content))))
+Media files, if present, are placed in `gptel-context--alist'."
+  (when-let* ((media-list (gptel-context--collect-media))
+              (media-processed (gptel--ollama-parse-multipart media-list)))
+    (cl-callf (lambda (images)
+                (vconcat (plist-get media-processed :images)
+                         images))
+        (plist-get (car prompts) :images))))
 
 ;;;###autoload
 (cl-defun gptel-make-ollama

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -245,7 +245,7 @@ format."
 (cl-defmethod gptel--inject-media ((_backend gptel-ollama) prompts)
   "Wrap the first user prompt in PROMPTS with included media files.
 
-Media files, if present, are placed in `gptel-context--alist'."
+Media files, if present, are placed in `gptel-context'."
   (when-let* ((media-list (gptel-context--collect-media))
               (media-processed (gptel--ollama-parse-multipart media-list)))
     (cl-callf (lambda (images)

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -496,33 +496,19 @@ format."
    into parts-array
    finally return (vconcat parts-array)))
 
-;; TODO: Does this need to be a generic function?
-(cl-defmethod gptel--wrap-user-prompt ((_backend gptel-openai) prompts
-                                       &optional inject-media)
-  "Wrap the last user prompt in PROMPTS with the context string.
+(cl-defmethod gptel--inject-media ((_backend gptel-openai) prompts)
+  "Wrap the first user prompt in PROMPTS with included media files.
 
-If INJECT-MEDIA is non-nil wrap it with base64-encoded media
-files in the context."
-  (if inject-media
-      ;; Wrap the first user prompt with included media files/contexts
-      (when-let* ((media-list (gptel-context--collect-media)))
-        (cl-callf (lambda (current)
-                    (vconcat
-                     (gptel--openai-parse-multipart media-list)
-                     (cl-typecase current
-                       (string `((:type "text" :text ,current)))
-                       (vector current)
-                       (t current))))
-            (plist-get (car prompts) :content)))
-    ;; Wrap the last user prompt with included text contexts
+Media files, if present, are placed in `gptel-context--alist'."
+  (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
-                (cl-etypecase current
-                  (string (gptel-context--wrap current))
-                  (vector (if-let* ((wrapped (gptel-context--wrap nil)))
-                              (vconcat `((:type "text" :text ,wrapped))
-                                       current)
-                            current))))
-        (plist-get (car (last prompts)) :content))))
+                (vconcat
+                 (gptel--openai-parse-multipart media-list)
+                 (cl-typecase current
+                   (string `((:type "text" :text ,current)))
+                   (vector current)
+                   (t current))))
+        (plist-get (car prompts) :content))))
 
 ;;;###autoload
 (cl-defun gptel-make-openai

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -499,7 +499,7 @@ format."
 (cl-defmethod gptel--inject-media ((_backend gptel-openai) prompts)
   "Wrap the first user prompt in PROMPTS with included media files.
 
-Media files, if present, are placed in `gptel-context--alist'."
+Media files, if present, are placed in `gptel-context'."
   (when-let* ((media-list (gptel-context--collect-media)))
     (cl-callf (lambda (current)
                 (vconcat

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1486,7 +1486,7 @@ implementation, used by OpenAI-compatible APIs and Ollama."
 This will be injected into the messages list in the prompt to
 send to the LLM.")
 
-;; FIXME(fsm) unify this with `gptel--wrap-user-prompt', which is a mess
+;; FIXME(fsm) unify this with `gptel--inject-media', which is a mess
 (cl-defgeneric gptel--inject-prompt
     (_backend data new-prompt &optional _position)
   "Append NEW-PROMPT to existing prompts in query DATA.
@@ -2011,7 +2011,7 @@ Initiate the request when done."
         ;; TODO(augment): Find a way to do this in the prompt-buffer?
         (when (and gptel-context--alist gptel-use-context
                    gptel-track-media (gptel--model-capable-p 'media))
-          (gptel--wrap-user-prompt gptel-backend full-prompt 'media))
+          (gptel--inject-media gptel-backend full-prompt))
         (unless stream (cl-remf info :stream))
         (plist-put info :backend gptel-backend)
         (when gptel-include-reasoning   ;Required for next-request-only scope
@@ -2211,7 +2211,7 @@ for inclusion into the user prompt for the gptel request."
       (push (list :text (buffer-substring-no-properties from-pt end)) parts))
     (nreverse parts)))
 
-(cl-defgeneric gptel--wrap-user-prompt (backend _prompts)
+(cl-defgeneric gptel--inject-media (backend _prompts)
   "Wrap the last prompt in PROMPTS with gptel's context.
 
 PROMPTS is a structure as returned by `gptel--parse-buffer'.

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -390,13 +390,13 @@ which see."
 (defun gptel--describe-infix-context ()
   (if (null gptel-context--alist) "Context"
     (pcase-let*
-        ((contexts (gptel-context--collect))
-         (buffer-count (length contexts))
+        ((buffer-count (length gptel-context--alist))
          (`(,file-count ,ov-count)
           (if (> buffer-count 0)
-              (cl-loop for (buf-file . ovs) in contexts
+              (cl-loop for entry in gptel-context--alist
+                       for (buf-file . ovs) = (ensure-list entry)
                        if (bufferp buf-file)
-                       sum (length ovs) into ov-count
+                       sum (if ovs (length ovs) 1) into ov-count
                        else count (stringp buf-file) into file-count
                        finally return (list file-count ov-count))
             (list 0 0))))

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -388,12 +388,12 @@ which see."
     gptel--crowdsourced-prompts))
 
 (defun gptel--describe-infix-context ()
-  (if (null gptel-context--alist) "Context"
+  (if (null gptel-context) "Context"
     (pcase-let*
-        ((buffer-count (length gptel-context--alist))
+        ((buffer-count (length gptel-context))
          (`(,file-count ,ov-count)
           (if (> buffer-count 0)
-              (cl-loop for entry in gptel-context--alist
+              (cl-loop for entry in gptel-context
                        for (buf-file . ovs) = (ensure-list entry)
                        if (bufferp buf-file)
                        sum (if ovs (length ovs) 1) into ov-count
@@ -443,8 +443,8 @@ which see."
                                    (concat (pth "buffer ") (ptv (substring s 1)))))
                             args))))
       (setq context
-            (and gptel-context--alist
-                 (let ((lc (length gptel-context--alist)))
+            (and gptel-context
+                 (let ((lc (length gptel-context)))
                    (concat (pth " along with ") (ptv (format "%d" lc))
                            (pth (concat " context source" (and (/= lc 1) "s")))))))
       (cond ((member "m" args)
@@ -1357,7 +1357,7 @@ supports.  See `gptel-track-media' for more information."
 
 (transient-define-suffix gptel--infix-context-remove-all ()
   "Clear gptel's context."
-  :if (lambda () gptel-context--alist)
+  :if (lambda () gptel-context)
   :transient 'transient--do-stay
   :key "-d"
   :description "Remove all"
@@ -1917,7 +1917,7 @@ whether the action is confirmed/cancelled."
   "Display all contexts from all buffers & files."
   :transient 'transient--do-exit
   :key " C"
-  :if (lambda () gptel-context--alist)
+  :if (lambda () gptel-context)
   :description "Inspect context"
   (interactive)
   (gptel-context--buffer-setup))

--- a/gptel.el
+++ b/gptel.el
@@ -573,9 +573,10 @@ which see for BEG, END and PRE."
                                 'help-echo "System message for session"))
                               (context
                                (and gptel-context--alist
-                                (cl-loop for entry in gptel-context--alist
-                                 if (bufferp (car entry)) count it into bufs
-                                 else count (stringp (car entry)) into files
+                                (cl-loop
+                                 for entry in gptel-context--alist
+                                 if (bufferp (or (car-safe entry) entry)) count it into bufs
+                                 else count (stringp (or (car-safe entry) entry)) into files
                                  finally return
                                  (propertize
                                   (buttonize

--- a/gptel.el
+++ b/gptel.el
@@ -572,26 +572,26 @@ which see for BEG, END and PRE."
                                 'mouse-face 'highlight
                                 'help-echo "System message for session"))
                               (context
-                               (and gptel-context--alist
-                                (cl-loop
-                                 for entry in gptel-context--alist
-                                 if (bufferp (or (car-safe entry) entry)) count it into bufs
-                                 else count (stringp (or (car-safe entry) entry)) into files
-                                 finally return
-                                 (propertize
-                                  (buttonize
-                                   (concat "[Context: "
-                                    (and (> bufs 0) (format "%d buf" bufs))
-                                    (and (> bufs 1) "s")
-                                    (and (> bufs 0) (> files 0) ", ")
-                                    (and (> files 0) (format "%d file" files))
-                                    (and (> files 1) "s")
-                                    "]")
-                                   (lambda (&rest _)
-                                     (require 'gptel-context)
-                                     (gptel-context--buffer-setup)))
-                                  'mouse-face 'highlight
-                                  'help-echo "Active gptel context"))))
+                               (and gptel-context
+                                    (cl-loop
+                                     for entry in gptel-context
+                                     if (bufferp (or (car-safe entry) entry)) count it into bufs
+                                     else count (stringp (or (car-safe entry) entry)) into files
+                                     finally return
+                                     (propertize
+                                      (buttonize
+                                       (concat "[Context: "
+                                               (and (> bufs 0) (format "%d buf" bufs))
+                                               (and (> bufs 1) "s")
+                                               (and (> bufs 0) (> files 0) ", ")
+                                               (and (> files 0) (format "%d file" files))
+                                               (and (> files 1) "s")
+                                               "]")
+                                       (lambda (&rest _)
+                                         (require 'gptel-context)
+                                         (gptel-context--buffer-setup)))
+                                      'mouse-face 'highlight
+                                      'help-echo "Active gptel context"))))
                               (toggle-track-media
                                (lambda (&rest _)
                                  (setq-local gptel-track-media


### PR DESCRIPTION
There are multiple-PRs that either duplicate each other or have merge-conflicts. 
This is a synthesis of all of these: #895 #925 #996 #1007 #983 

What does this do ?
- #925
Add profile-argument from; replace ```profile``` keyword with ```aws-profile```.
-  #895
Use :static argument for ```aws-profile``` for IAM cred.
- #996
Switch precedence; use aws-profile when provided.
- #1007 
Use ```AWS_BEARER_TOKEN_BEDROCK``` if provided at highest-precedence.
- #983 
Use ```aws-bearer-token``` if provided at highest-precedence.

If the authors of these PRs can test these out, we can push this in.
(@liangfu @leezu @lgfang @andykuszyk )