### PR TITLE
gptel-integrations: Add sync mcp server init

### DIFF
--- a/gptel-integrations.el
+++ b/gptel-integrations.el
@@ -58,7 +58,8 @@ considered.
 If INTERACTIVE is non-nil (or called interactively), guide the user
 through setting up mcp, and query for servers to retrieve tools from.
 
-Call SERVER-CALLBACK after starting MCP servers."
+Call SERVER-CALLBACK after starting MCP servers.  If SERVER-CALLBACK is
+not a function and non-nil, start SERVERS synchronously."
   (interactive (list nil nil t))
   (if (locate-library "mcp-hub")
       (unless (require 'mcp-hub nil t)
@@ -119,8 +120,9 @@ Call SERVER-CALLBACK after starting MCP servers."
                       (when (functionp server-callback) (funcall server-callback))))))
 
             (if inactive-servers        ;start servers
-                (mcp-hub-start-all-server
-                 add-all-tools (mapcar #'car inactive-servers))
+                (let ((syncp (and server-callback (not (functionp server-callback)) t)))
+                  (mcp-hub-start-all-server
+                   add-all-tools (mapcar #'car inactive-servers) syncp))
               (funcall add-all-tools (mapcar #'car servers))))
         (message "All MCP tools are already available to gptel!")
         (when (functionp server-callback) (funcall server-callback))))))


### PR DESCRIPTION
This change requires `mcp.el` commit
5f06a78fe74f58888f115bf30838ede5e013f4af or later. See https://github.com/lizqwerscott/mcp.el/commit/5f06a78fe74f58888f115bf30838ede5e013f4af.

* gptel-integrations.el (gptel-mcp-connect): Add `syncp` argument which gets passed to `mcp-hub-start-all-server` in order to initialize the mcp server synchronously.

This completes #971 