### PR TITLE
gptel-gh: Change how tokens are managed

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,6 +69,7 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
     - [[#other-llm-backends][Other LLM backends]]
       - [[#optional-securing-api-keys-with-authinfo][(Optional) Securing API keys with =authinfo=]]
       - [[#optional-reading-api-keys-from-environment-variables][(Optional) Reading API keys from environment variables]]
+      - [[#optional-custom-oauth-token-storage][(Optional) Custom OAuth token storage]]
       - [[#openai-chatgpt-pluspro-subscription][OpenAI (ChatGPT plus/pro subscription)]]
       - [[#azure][Azure]]
       - [[#gpt4all][GPT4All]]
@@ -302,6 +303,25 @@ it will try to guess the key from the backend type, /i.e./ try to use
 
 #+html: </details>
 #+html: <details><summary>
+**** (Optional) Custom OAuth token storage
+:PROPERTIES:
+:CUSTOM_ID: optional-custom-oauth-token-storage
+:END:
+#+html: </summary>
+
+For OAuth-based backends (GitHub Copilot, OpenAI OAuth), tokens are stored by default in cleartext files. You can customize this behavior by setting the variables =gptel-oauth-token-load-function= and =gptel-oauth-token-save-function=. These are global variables that affect all OAuth backends. For example, if tokens are stored in a password manager:
+
+#+begin_src emacs-lisp
+  (setq
+   ;; Prompt user to provide the token as a password
+   gptel-oauth-token-load-function (lambda (account-hint) (read-passwd (format "Token for '%s': " account-hint)))
+
+   ;; Display a message when a new token has been stored, so that it can be copied from the message history
+   gptel-oauth-token-save-function (lambda (account-hint token) (message "New token for '%s' saved" account-hint)))
+#+end_src
+
+#+html: </details>
+#+html: <details><summary>
 **** OpenAI (ChatGPT plus/pro subscription)
 #+html: </summary>
 
@@ -312,6 +332,8 @@ Includes access to OpenAI Codex models. Register a backend with
 #+end_src
 
 You will be prompted to log into OpenAI as required.  (You can also log in manually with =M-x gptel-openai-oauth-login=.)
+
+To customize token storage (e.g., use a password manager), see [[#optional-custom-oauth-token-storage][Custom OAuth token storage]].
 
 If you are using it through a proxy, you can specify the host name, protocol etc:
 
@@ -1134,16 +1156,7 @@ You will be informed to login into =GitHub= as required.  (You can also log in m
 
 You can pick this backend from the menu when using gptel (see [[#usage][Usage]]).
 
-The GitHub OAuth token is stored by default in a cleartext file based on the path stored in =gptel-gh-github-token-file=. It is possible to customize the variables =gptel-gh-github-token-load-function= and =gptel-gh-github-token-save-function= to change this behavior. If the token is e.g. stored in a password manager, then the following example can be used to so that the token is read as a password:
-
-#+begin_src emacs-lisp
-  (setq
-   ;; Prompt user to provide the token as a password
-   gptel-gh-github-token-load-function (lambda (account-hint) (read-passwd (format "Copilot token for '%s': " account-hint)))
-
-   ;; Display a message when a new token has been stored, so that it can be copied from the message history
-   gptel-gh-github-token-save-function (lambda (account-hint token) (message "New token for '%s' saved: %s" account-hint token))
-#+end_src
+The GitHub OAuth token is stored by default in a cleartext file based on the path stored in =gptel-gh-github-token-file=. To customize token storage (e.g., use a password manager), see [[#optional-custom-oauth-token-storage][Custom OAuth token storage]].
 
 ***** (Optional) Set as the default gptel backend
 
@@ -1810,6 +1823,13 @@ Other Emacs clients for LLMs prescribe the format of the interaction (a comint s
 | =gptel-curl-extra-args= | Extra arguments passed to Curl.                                    |
 | =gptel-api-key=         | Variable/function that returns the API key for the active backend. |
 |-------------------------+--------------------------------------------------------------------|
+
+|--------------------------------+----------------------------------------------------------------|
+| *OAuth token options*          |                                                                |
+|--------------------------------+----------------------------------------------------------------|
+| =gptel-oauth-token-load-function= | Function to load OAuth tokens (override file-based storage)   |
+| =gptel-oauth-token-save-function= | Function to save OAuth tokens (override file-based storage)   |
+|--------------------------------+----------------------------------------------------------------|
 
 |-----------------------+---------------------------------------------------------|
 | *LLM request options* | /(Note: not supported uniformly across LLMs)/           |

--- a/README.org
+++ b/README.org
@@ -309,16 +309,48 @@ it will try to guess the key from the backend type, /i.e./ try to use
 :END:
 #+html: </summary>
 
-For OAuth-based backends (GitHub Copilot, OpenAI OAuth), tokens are stored by default in cleartext files. You can customize this behavior by setting the variables =gptel-oauth-token-load-function= and =gptel-oauth-token-save-function=. These are global variables that affect all OAuth backends. For example, if tokens are stored in a password manager:
+For OAuth-based backends (GitHub Copilot, OpenAI OAuth), tokens are stored by default in cleartext files. You can customize this behavior by setting the variables =gptel-oauth-token-load-function= and =gptel-oauth-token-save-function=. These are global variables that affect all OAuth backends.
+
+**Important**: Different backends use different token formats:
+- =GitHub Copilot= (=gptel-gh=): tokens are simple strings
+- =OpenAI OAuth= (=gptel-openai-oauth=): tokens are plists with multiple fields
+
+Here's an example configuration for manual copy/paste workflow:
 
 #+begin_src emacs-lisp
   (setq
-   ;; Prompt user to provide the token as a password
-   ;; backend-type is a symbol like 'gptel-gh or 'gptel-openai-oauth
-   gptel-oauth-token-load-function (lambda (backend-type account-hint) (read-passwd (format "Token for '%s' (%s): " account-hint backend-type)))
+   ;; Load function - prompt user to paste token
+   ;; For GitHub: paste the access token string
+   ;; For OpenAI OAuth: paste the plist (use %S format from save messages)
+   gptel-oauth-token-load-function
+   (lambda (backend-type account-hint)
+     (pcase backend-type
+       ('gptel-gh
+        ;; GitHub: tokens are strings
+        (read-passwd (format "GitHub token for '%s': " account-hint)))
+       ('gptel-openai-oauth
+        ;; OpenAI OAuth: tokens are plists - convert string to plist
+        (let ((token-str (read-passwd (format "OpenAI OAuth token plist for '%s': " account-hint))))
+          (when (and token-str (not (string-empty-p token-str)))
+            (condition-case nil
+                (read token-str)  ;; Convert string to plist
+              (error
+               (message "Invalid OpenAI OAuth token format!")
+               nil)))))
+       (_ nil)))
 
-   ;; Display a message when a new token has been stored, so that it can be copied from the message history
-   gptel-oauth-token-save-function (lambda (backend-type account-hint token) (message "New token for '%s' (%s) saved" account-hint backend-type)))
+   ;; Save function - display token for copying to password manager
+   gptel-oauth-token-save-function
+   (lambda (backend-type account-hint token)
+     (pcase backend-type
+       ('gptel-gh
+        ;; GitHub: display string token
+        (message "GitHub token for '%s': %s" account-hint token))
+       ('gptel-openai-oauth
+        ;; OpenAI OAuth: display plist (use %S for copy/paste format)
+        (message "OpenAI OAuth token for '%s': %S" account-hint token))
+       (_
+        (message "Unknown backend type: %s" backend-type)))))
 #+end_src
 
 #+html: </details>

--- a/README.org
+++ b/README.org
@@ -1134,6 +1134,17 @@ You will be informed to login into =GitHub= as required.  (You can also log in m
 
 You can pick this backend from the menu when using gptel (see [[#usage][Usage]]).
 
+The GitHub OAuth token is stored by default in a cleartext file based on the path stored in =gptel-gh-github-token-file=. It is possible to customize the variables =gptel-gh-github-token-load-function= and =gptel-gh-github-token-save-function= to change this behavior. If the token is e.g. stored in a password manager, then the following example can be used to so that the token is read as a password:
+
+#+begin_src emacs-lisp
+  (setq
+   ;; Prompt user to provide the token as a password
+   gptel-gh-github-token-load-function (lambda (account-hint) (read-passwd (format "Copilot token for '%s': " account-hint)))
+
+   ;; Display a message when a new token has been stored, so that it can be copied from the message history
+   gptel-gh-github-token-save-function (lambda (account-hint token) (message "New token for '%s' saved: %s" account-hint token))
+#+end_src
+
 ***** (Optional) Set as the default gptel backend
 
 The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.

--- a/README.org
+++ b/README.org
@@ -314,10 +314,11 @@ For OAuth-based backends (GitHub Copilot, OpenAI OAuth), tokens are stored by de
 #+begin_src emacs-lisp
   (setq
    ;; Prompt user to provide the token as a password
-   gptel-oauth-token-load-function (lambda (account-hint) (read-passwd (format "Token for '%s': " account-hint)))
+   ;; backend-type is a symbol like 'gptel-gh or 'gptel-openai-oauth
+   gptel-oauth-token-load-function (lambda (backend-type account-hint) (read-passwd (format "Token for '%s' (%s): " account-hint backend-type)))
 
    ;; Display a message when a new token has been stored, so that it can be copied from the message history
-   gptel-oauth-token-save-function (lambda (account-hint token) (message "New token for '%s' saved" account-hint)))
+   gptel-oauth-token-save-function (lambda (backend-type account-hint token) (message "New token for '%s' (%s) saved" account-hint backend-type)))
 #+end_src
 
 #+html: </details>

--- a/README.org
+++ b/README.org
@@ -311,7 +311,7 @@ it will try to guess the key from the backend type, /i.e./ try to use
 
 For OAuth-based backends (GitHub Copilot, OpenAI OAuth), tokens are stored by default in cleartext files. You can customize this behavior by setting the variables =gptel-oauth-token-load-function= and =gptel-oauth-token-save-function=. These are global variables that affect all OAuth backends.
 
-**Important**: Different backends use different token formats:
+*Important*: Different backends use different token formats:
 - =GitHub Copilot= (=gptel-gh=): tokens are simple strings
 - =OpenAI OAuth= (=gptel-openai-oauth=): tokens are plists with multiple fields
 

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -319,7 +319,7 @@ instead of attempting to open a browser automatically."
   (let ((gh-backends (gptel--gh-get-backends-by-account-hint account-hint)))
     ;; It shall only be possible to login when there exists a corresponding backend
     (if (= (length gh-backends) 0)
-        (user-error "No GitHub CoPilot backend found for account hint '%s'" account-hint))
+        (user-error "No GitHub Copilot backend found for account hint '%s'" account-hint))
     (pcase-let (((map :device_code :user_code :verification_uri)
                  (gptel--url-retrieve
                      "https://github.com/login/device/code"

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -275,7 +275,7 @@
 (defun gptel-gh--get-save-token-function (account-hint token)
   (if #'gptel-oauth-token-save-function
       (gptel-oauth-token-save-function 'gptel-gh account-hint token)
-    (gptel--gh-save-token-to-file account-hint token))
+    (gptel--gh-save-token-to-file account-hint token)))
 
 ;; https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 (defun gptel--gh-uuid ()

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -257,10 +257,21 @@
    #'gptel-gh--get-load-token-function
    account-hint))
 
+(defun gptel--gh-validate-token-p (token)
+  "Check if TOKEN is a valid non-empty GitHub token string."
+  (and (stringp token) (not (string-empty-p token))))
+
 (defun gptel-gh--get-load-token-function (account-hint)
-  (if #'gptel-oauth-token-load-function
-      (gptel-oauth-token-load-function 'gptel-gh account-hint)
-    (gptel-oauth--read-token (gptel--gh-generate-token-filename account-hint))))
+  "Load GitHub token from file, ensuring it is a string."
+  (let ((token (if #'gptel-oauth-token-load-function
+                  (gptel-oauth-token-load-function 'gptel-gh account-hint)
+                (gptel-oauth--read-token (gptel--gh-generate-token-filename account-hint)))))
+    ;; Filter out nil and empty values (empty files do not contain tokens)
+    (when (and token (not (equal token "")))
+      (unless (gptel--gh-validate-token-p token)
+        (message "Ignoring invalid GitHub token format in file: expected string, got %S" token)
+        (setq token nil))
+      token)))
 
 (defun gptel--gh-save-token (account-hint token)
   "Function that updates the GitHub OAuth token cache and calls the save function."
@@ -273,6 +284,9 @@
    token))
 
 (defun gptel-gh--get-save-token-function (account-hint token)
+  "Save GitHub TOKEN to file for ACCOUNT-HINT, ensuring it is a string."
+  (unless (gptel--gh-validate-token-p token)
+    (user-error "Cannot save invalid GitHub token: expected string, got %S" token))
   (if #'gptel-oauth-token-save-function
       (gptel-oauth-token-save-function 'gptel-gh account-hint token)
     (gptel-oauth--write-token (gptel--gh-generate-token-filename account-hint) token)))

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -353,8 +353,7 @@ Then we need a session token."
                (gptel--gh-token gptel-backend)))
     (when (or (null token)
               (and expires_at
-                   (> (round (float-time (current-time)))
-                      expires_at)))
+                   (> (round (float-time)) expires_at)))
       (gptel--gh-renew-token))))
 
 (cl-defmethod gptel-curl--parse-stream ((backend gptel--gh) info)

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -275,7 +275,7 @@
 (defun gptel-gh--get-save-token-function (account-hint token)
   (if #'gptel-oauth-token-save-function
       (gptel-oauth-token-save-function 'gptel-gh account-hint token)
-    (gptel--gh-save-token-to-file account-hint token)))
+    (gptel-oauth--write-token (gptel--gh-generate-token-filename account-hint) token)))
 
 ;; https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 (defun gptel--gh-uuid ()
@@ -302,10 +302,6 @@
    gptel-gh-github-token-file
    #'gptel-oauth--validate-account-hint
    account-hint))
-
-(defun gptel--gh-save-token-to-file (account-hint token)
-  "Save GitHub TOKEN to file using ACCOUNT-HINT."
-  (gptel-oauth--save-token-to-file #'gptel--gh-generate-token-filename account-hint token))
 
 (defun gptel-gh-login (account-hint)
   "Login to GitHub Copilot API.

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -263,7 +263,7 @@
 
 (defun gptel-gh--get-load-token-function (account-hint)
   "Load GitHub token from file, ensuring it is a string."
-  (let ((token (if #'gptel-oauth-token-load-function
+  (let ((token (if gptel-oauth-token-load-function
                   (funcall gptel-oauth-token-load-function 'gptel-gh account-hint)
                 (gptel-oauth--read-token (gptel--gh-generate-token-filename account-hint)))))
     ;; Filter out nil and empty values (empty files do not contain tokens)
@@ -287,7 +287,7 @@
   "Save GitHub TOKEN to file for ACCOUNT-HINT, ensuring it is a string."
   (unless (gptel--gh-validate-token-p token)
     (user-error "Cannot save invalid GitHub token: expected string, got %S" token))
-  (if #'gptel-oauth-token-save-function
+  (if gptel-oauth-token-save-function
       (funcall gptel-oauth-token-save-function 'gptel-gh account-hint token)
     (gptel-oauth--write-token (gptel--gh-generate-token-filename account-hint) token)))
 

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -264,7 +264,7 @@
 (defun gptel-gh--get-load-token-function (account-hint)
   "Load GitHub token from file, ensuring it is a string."
   (let ((token (if #'gptel-oauth-token-load-function
-                  (gptel-oauth-token-load-function 'gptel-gh account-hint)
+                  (funcall gptel-oauth-token-load-function 'gptel-gh account-hint)
                 (gptel-oauth--read-token (gptel--gh-generate-token-filename account-hint)))))
     ;; Filter out nil and empty values (empty files do not contain tokens)
     (when (and token (not (equal token "")))
@@ -288,7 +288,7 @@
   (unless (gptel--gh-validate-token-p token)
     (user-error "Cannot save invalid GitHub token: expected string, got %S" token))
   (if #'gptel-oauth-token-save-function
-      (gptel-oauth-token-save-function 'gptel-gh account-hint token)
+      (funcall gptel-oauth-token-save-function 'gptel-gh account-hint token)
     (gptel-oauth--write-token (gptel--gh-generate-token-filename account-hint) token)))
 
 ;; https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -300,7 +300,6 @@
   "Generate token filename for GitHub backend with ACCOUNT-HINT."
   (gptel-oauth--generate-token-filename
    gptel-gh-github-token-file
-   #'gptel-oauth--validate-account-hint
    account-hint))
 
 (defun gptel-gh-login (account-hint)

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -227,17 +227,11 @@
 (cl-defstruct (gptel--gh (:include gptel-openai)
                          (:copier nil)
                          (:constructor gptel--make-gh))
-  token github-token sessionid machineid responses-backend)
+  token github-token sessionid machineid account-hint responses-backend)
 
 (defcustom gptel-gh-github-token-file (expand-file-name ".cache/copilot-chat/github-token"
                                                         user-emacs-directory)
   "File where the GitHub token is stored."
-  :type 'string
-  :group 'gptel)
-
-(defcustom gptel-gh-token-file (expand-file-name ".cache/copilot-chat/token"
-                                                 user-emacs-directory)
-  "File where the chat token is cached."
   :type 'string
   :group 'gptel)
 
@@ -247,6 +241,31 @@
     ("User-Agent" . ,(format "Emacs %s" emacs-version))))
 
 (defconst gptel--gh-client-id "Iv1.b507a08c87ecfe98")
+(defconst gptel--gh-default-username-placeholder "[Default account]")
+
+(defun gptel--gh-get-backends-by-account-hint (account-hint)
+  "Get all GitHub Copilot backends for a specific account hint."
+  (gptel-oauth--get-backends-by #'gptel--gh-p #'gptel--gh-account-hint account-hint))
+
+(defun gptel--gh-load-token (account-hint)
+  "Function that ensures that the GitHub OAuth token cache is used and is set."
+  (gptel-oauth--load-token
+   #'gptel--gh-p
+   #'gptel--gh-account-hint
+   #'gptel--gh-github-token
+   (lambda (b token) (setf (gptel--gh-github-token b) token))
+   (or gptel-oauth-token-load-function 'gptel--gh-restore-token-from-file)
+   account-hint))
+
+(defun gptel--gh-save-token (account-hint token)
+  "Function that updates the GitHub OAuth token cache and calls the save function."
+  (gptel-oauth--save-token
+   #'gptel--gh-p
+   #'gptel--gh-account-hint
+   (lambda (b token) (setf (gptel--gh-github-token b) token))
+   (or gptel-oauth-token-save-function 'gptel--gh-save-token-to-file)
+   account-hint
+   token))
 
 ;; https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 (defun gptel--gh-uuid ()
@@ -267,28 +286,40 @@
       (setq hex (nconc hex (list (aref hex-chars (random 16))))))
     (apply #'string hex)))
 
-(defun gptel-gh-login ()
+(defun gptel--gh-generate-token-filename (account-hint)
+  "Generate token filename for GitHub backend with ACCOUNT-HINT."
+  (gptel-oauth--generate-token-filename
+   gptel-gh-github-token-file
+   #'gptel-oauth--validate-account-hint
+   account-hint))
+
+(defun gptel--gh-restore-token-from-file (account-hint)
+  "Restore GitHub token from file using ACCOUNT-HINT."
+  (gptel-oauth--restore-token-from-file #'gptel--gh-generate-token-filename account-hint))
+
+(defun gptel--gh-save-token-to-file (account-hint token)
+  "Save GitHub TOKEN to file using ACCOUNT-HINT."
+  (gptel-oauth--save-token-to-file #'gptel--gh-generate-token-filename account-hint token))
+
+(defun gptel-gh-login (account-hint)
   "Login to GitHub Copilot API.
 
 This will prompt you to authorize in a browser and store the token.
 
+ACCOUNT-HINT is used to provide a hint which account to login to.
+It must match an existing backend.
+
 In SSH sessions, the URL and code will be displayed for manual entry
 instead of attempting to open a browser automatically."
-  (interactive)
-  ;; Determine which GitHub backend to use
-  (let ((gh-backend
-         (cond
-          ;; If current backend is GitHub, use it
-          ((and (boundp 'gptel-backend)
-                gptel-backend
-                (gptel--gh-p gptel-backend))
-           gptel-backend)
-          ;; Otherwise, find any GitHub backend
-          ((cl-find-if (lambda (b) (gptel--gh-p b))
-                       (mapcar #'cdr gptel--known-backends)))
-          ;; No GitHub backend found
-          (t (user-error "No GitHub Copilot backend found.  \
-Please set one up with `gptel-make-gh-copilot' first")))))
+  (interactive (list (gptel-oauth--read-account-hint
+                      #'gptel--gh-p #'gptel--gh-account-hint
+                      "Choose GitHub account: "
+                      gptel--gh-default-username-placeholder
+                      "No GitHub copilot backends registered")))
+  (let ((gh-backends (gptel--gh-get-backends-by-account-hint account-hint)))
+    ;; It shall only be possible to login when there exists a corresponding backend
+    (if (= (length gh-backends) 0)
+        (user-error "No GitHub CoPilot backend found for account hint '%s'" account-hint))
     (pcase-let (((map :device_code :user_code :verification_uri)
                  (gptel--url-retrieve
                      "https://github.com/login/device/code"
@@ -296,25 +327,22 @@ Please set one up with `gptel-make-gh-copilot' first")))))
                    :headers gptel--gh-auth-common-headers
                    :data `( :client_id ,gptel--gh-client-id
                             :scope "read:user"))))
-      (gptel-oauth--device-auth-prompt user_code verification_uri)
-      ;; Use gh-backend for token storage
-      (let ((resp-body (gptel--url-retrieve
-                           "https://github.com/login/oauth/access_token"
-                         :method 'post
-                         :headers gptel--gh-auth-common-headers
-                         :data `( :client_id ,gptel--gh-client-id
-                                  :device_code ,device_code
-                                  :grant_type "urn:ietf:params:oauth:grant-type:device_code"))))
-        (thread-last
-            (plist-get resp-body :access_token)
-          (gptel-oauth--write-token gptel-gh-github-token-file)
-          (setf (gptel--gh-github-token gh-backend)))))
-    ;; Check gh-backend for success
-    (if (and (gptel--gh-github-token gh-backend)
-             (not (string-empty-p
-                   (gptel--gh-github-token gh-backend))))
-        (message "Successfully logged in to GitHub Copilot.")
-      (user-error "Error: You might not have access to GitHub Copilot Chat!"))))
+
+      (gptel-oauth--device-auth-prompt user_code verification_uri account-hint)
+      (let ((github-token
+             (plist-get
+              (gptel--url-retrieve
+                  "https://github.com/login/oauth/access_token"
+                :method 'post
+                :headers gptel--gh-auth-common-headers
+                :data `( :client_id ,gptel--gh-client-id
+                         :device_code ,device_code
+                         :grant_type "urn:ietf:params:oauth:grant-type:device_code"))
+              :access_token)))
+        (if (or (null github-token) (string-empty-p github-token))
+            (user-error "Error: You might not have access to GitHub Copilot Chat!"))
+        (message "Successfully logged in to GitHub Copilot")
+        (gptel--gh-save-token account-hint github-token)))))
 
 (defun gptel--gh-renew-token ()
   "Renew session token."
@@ -326,12 +354,8 @@ Please set one up with `gptel-make-gh-copilot' first")))))
                        . ,(format "token %s" (gptel--gh-github-token gptel-backend)))
                       ,@gptel--gh-auth-common-headers))))
     (if (not (plist-get token :token))
-        (progn
-          (setf (gptel--gh-github-token gptel-backend) nil)
-          (user-error "Error: You might not have access to GitHub Copilot Chat!"))
-      (thread-last token
-        (gptel-oauth--write-token gptel-gh-token-file)
-        (setf (gptel--gh-token gptel-backend))))))
+        (user-error "Error: You might not have access to GitHub Copilot Chat!")
+      (setf (gptel--gh-token gptel-backend) token))))
 
 (defun gptel--gh-auth ()
   "Authenticate with GitHub Copilot API.
@@ -339,15 +363,11 @@ Please set one up with `gptel-make-gh-copilot' first")))))
 We first need github authorization (github token).
 Then we need a session token."
   (unless (gptel--gh-github-token gptel-backend)
-    (let ((token (gptel-oauth--read-token gptel-gh-github-token-file)))
+    (let* ((account-hint (gptel--gh-account-hint gptel-backend))
+           (token (gptel--gh-load-token account-hint)))
       (if token
           (setf (gptel--gh-github-token gptel-backend) token)
-        (gptel-gh-login))))
-
-  (when (null (gptel--gh-token gptel-backend))
-    ;; try to load token from `gptel-gh-token-file'
-    (setf (gptel--gh-token gptel-backend)
-          (gptel-oauth--read-token gptel-gh-token-file)))
+        (gptel-gh-login account-hint))))
 
   (pcase-let (((map :token :expires_at)
                (gptel--gh-token gptel-backend)))
@@ -358,19 +378,19 @@ Then we need a session token."
 
 (cl-defmethod gptel-curl--parse-stream ((backend gptel--gh) info)
   (let ((model (plist-get info :model)))
-   (if (gptel--model-capable-p 'responses-api model)
-       ;; Defer to gptel-openai-responses backend
-       (gptel-curl--parse-stream
-        (gptel--gh-responses-backend backend) info)
-     (cl-call-next-method))))
+    (if (gptel--model-capable-p 'responses-api model)
+        ;; Defer to gptel-openai-responses backend
+        (gptel-curl--parse-stream
+         (gptel--gh-responses-backend backend) info)
+      (cl-call-next-method))))
 
 (cl-defmethod gptel--parse-response ((backend gptel--gh) response info)
   (let ((model (plist-get info :model)))
     (if (gptel--model-capable-p 'responses-api model)
-       ;; Defer to gptel-openai-responses backend
-       (gptel--parse-response
-        (gptel--gh-responses-backend backend) response info)
-     (cl-call-next-method))))
+        ;; Defer to gptel-openai-responses backend
+        (gptel--parse-response
+         (gptel--gh-responses-backend backend) response info)
+      (cl-call-next-method))))
 
 (cl-defmethod gptel--request-data ((backend gptel--gh) prompts)
   (if (gptel--model-capable-p 'responses-api gptel-model)
@@ -419,7 +439,7 @@ Then we need a session token."
 
 ;;;###autoload
 (cl-defun gptel-make-gh-copilot
-    (name &key curl-args request-params
+    (name &key (account-hint "") curl-args request-params
           (header
            (lambda (info) (gptel--gh-auth)
              `(("openai-intent" . "conversation-panel")
@@ -443,6 +463,10 @@ Then we need a session token."
   "Register a Github Copilot chat backend for gptel with NAME.
 
 Keyword arguments:
+
+ACCOUNT-HINT (optional) is an indicator of which GitHub account to associate
+the backend with. This enables backends to be logged in as a separate user. Note
+that this is only a hint and will be used when a token is saved/loaded.
 
 CURL-ARGS (optional) is a list of additional Curl arguments.
 
@@ -491,6 +515,7 @@ parameters (as plist keys) and values supported by the API.  Use
 these to set parameters that gptel does not provide user options
 for."
   (declare (indent 1))
+  (gptel-oauth--validate-account-hint account-hint)
   (let* ((url (lambda (_info)
                 (concat protocol "://" host
                         (if (gptel--model-capable-p 'responses-api gptel-model)
@@ -505,6 +530,7 @@ for."
                    :stream stream
                    :request-params request-params
                    :curl-args curl-args
+                   :account-hint account-hint
                    :url url
                    :machineid (gptel--gh-machine-id)
                    :responses-backend

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -260,7 +260,7 @@
 (defun gptel-gh--get-load-token-function (account-hint)
   (if #'gptel-oauth-token-load-function
       (gptel-oauth-token-load-function 'gptel-gh account-hint)
-    (gptel--gh-restore-token-from-file account-hint)))
+    (gptel-oauth--read-token (gptel--gh-generate-token-filename account-hint))))
 
 (defun gptel--gh-save-token (account-hint token)
   "Function that updates the GitHub OAuth token cache and calls the save function."
@@ -302,10 +302,6 @@
    gptel-gh-github-token-file
    #'gptel-oauth--validate-account-hint
    account-hint))
-
-(defun gptel--gh-restore-token-from-file (account-hint)
-  "Restore GitHub token from file using ACCOUNT-HINT."
-  (gptel-oauth--restore-token-from-file #'gptel--gh-generate-token-filename account-hint))
 
 (defun gptel--gh-save-token-to-file (account-hint token)
   "Save GitHub TOKEN to file using ACCOUNT-HINT."

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -254,8 +254,13 @@
    #'gptel--gh-account-hint
    #'gptel--gh-github-token
    (lambda (b token) (setf (gptel--gh-github-token b) token))
-   (or gptel-oauth-token-load-function 'gptel--gh-restore-token-from-file)
+   #'gptel-gh--get-load-token-function
    account-hint))
+
+(defun gptel-gh--get-load-token-function (account-hint)
+  (if #'gptel-oauth-token-load-function
+      (gptel-oauth-token-load-function 'gptel-gh account-hint)
+    (gptel--gh-restore-token-from-file account-hint)))
 
 (defun gptel--gh-save-token (account-hint token)
   "Function that updates the GitHub OAuth token cache and calls the save function."
@@ -263,9 +268,14 @@
    #'gptel--gh-p
    #'gptel--gh-account-hint
    (lambda (b token) (setf (gptel--gh-github-token b) token))
-   (or gptel-oauth-token-save-function 'gptel--gh-save-token-to-file)
+   #'gptel-gh--get-save-token-function
    account-hint
    token))
+
+(defun gptel-gh--get-save-token-function (account-hint token)
+  (if #'gptel-oauth-token-save-function
+      (gptel-oauth-token-save-function 'gptel-gh account-hint token)
+    (gptel--gh-save-token-to-file account-hint token))
 
 ;; https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 (defun gptel--gh-uuid ()

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -210,10 +210,9 @@ matching PREDICATE and ACCOUNT-HINT."
             (cached-token (funcall token-getter backend)))
       cached-token
     (let ((token (funcall load-function account-hint)))
-      (when (and token (not (equal token "")))
-        ;; Propagate to all matching backends
-        (dolist (b (gptel-oauth--get-backends-by predicate account-hint-accessor account-hint) token)
-          (funcall token-setter b token))))))
+      ;; Propagate to all matching backends
+      (dolist (b (gptel-oauth--get-backends-by predicate account-hint-accessor account-hint) token)
+        (funcall token-setter b token)))))
 
 (defun gptel-oauth--save-token (predicate account-hint-accessor token-setter
                                           save-function account-hint token)

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -33,9 +33,7 @@
 ;;; Token Storage
 
 (defun gptel-oauth--write-token (file token)
-  "Write TOKEN to FILE.
-
-TOKEN is a plist suitable for later restoration from FILE."
+  "Write TOKEN to FILE."
   (let ((print-length nil)
         (print-level nil)
         (coding-system-for-write 'utf-8-unix))
@@ -44,7 +42,7 @@ TOKEN is a plist suitable for later restoration from FILE."
     token))
 
 (defun gptel-oauth--read-token (file)
-  "Read a token plist from FILE.
+  "Read a token from FILE.
 
 Returns nil if FILE does not exist or cannot be read."
   (when (file-exists-p file)

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -58,6 +58,23 @@ Returns nil if FILE does not exist or cannot be read."
             (read (current-buffer))
           (error nil))))))
 
+;;; Token Storage Customization
+
+(defcustom gptel-oauth-token-load-function nil
+  "Function to load OAuth tokens.
+Default is nil, meaning use backend-specific defaults.
+When set, this function is called with ACCOUNT-HINT and should return
+the token plist or nil.  Backends can customize this before use."
+  :type '(or null function)
+  :group 'gptel)
+
+(defcustom gptel-oauth-token-save-function nil
+  "Function to save OAuth tokens.
+Default is nil, meaning use backend-specific defaults.
+When set, this function is called with ACCOUNT-HINT and TOKEN."
+  :type '(or null function)
+  :group 'gptel)
+
 ;;; PKCE Implementation
 
 (defun gptel-oauth--base64url-encode (str)
@@ -96,12 +113,17 @@ Uses `random' to build a verifier string acceptable to PKCE."
 
 ;;; OAuth Flow
 
-(defun gptel-oauth--device-auth-prompt (user-code verification-uri)
-  "Prompt for device authorization.
+(defun gptel-oauth--device-auth-prompt (user-code verification-uri &optional account-hint)
+  "Prompt for device authorization for ACCOUNT-HINT.
 
 Copies USER-CODE to the clipboard and opens VERIFICATION-URI
-when appropriate for the current session."
-  (let ((in-ssh-session (or (getenv "SSH_CLIENT")
+when appropriate for the current session.
+If ACCOUNT-HINT is provided, displays which account is being logged into."
+  (let ((account-text (cond
+                       ((null account-hint) "Login")
+                       ((string= account-hint "") "Login for the default account.")
+                       (t (format "Login for '%s'." account-hint))))
+        (in-ssh-session (or (getenv "SSH_CLIENT")
                             (getenv "SSH_CONNECTION")
                             (getenv "SSH_TTY"))))
     (ignore-errors (gui-set-selection 'CLIPBOARD user-code))
@@ -109,17 +131,167 @@ when appropriate for the current session."
         (progn
           (message "Device Code: %s (copied to clipboard)" user-code)
           (read-from-minibuffer
-           (format "(One-time code %s copied) Visit %s in your local browser, \
+           (format "%s (One-time code %s copied) Visit %s in your local browser, \
 enter the code and authorize.  Press ENTER after authorizing: "
-                   user-code verification-uri)))
+                   account-text user-code verification-uri)))
       (read-from-minibuffer
-       (format "(One-time code %s copied) Press ENTER to open the authorization page. \
+       (format "%s (One-time code %s copied) Press ENTER to open the authorization page. \
 If your browser does not open automatically, browse to %s: "
-               user-code verification-uri))
+               account-text user-code verification-uri))
       (browse-url verification-uri)
       (read-from-minibuffer
-       (format "(One-time code %s copied) Press ENTER after authorizing: "
-               user-code)))))
+       (format "%s (One-time code %s copied) Press ENTER after authorizing: "
+               account-text user-code)))))
+
+;;; Account hint validation
+
+(defun gptel-oauth--validate-account-hint (account-hint)
+  "Validate ACCOUNT-HINT format for account identification.
+
+An empty string is considered valid for representing a default account.
+
+Valid account hints may contain alphanumeric characters, hyphens, and underscores,
+but cannot begin or end with a hyphen or underscore."
+  (cond
+   ;; Ensure that the account-hint is a string
+   ((not (stringp account-hint)) (user-error "Provided account hint is not a string"))
+
+   ;; Handle empty string case
+   ((= (length account-hint) 0) t)
+
+   ;; We have some characters, ensure they conform to reasonable rules
+   ((string-match-p "\\`[0-9A-Za-z]\\(?:[0-9A-Za-z]\\|-[0-9A-Za-z]\\|_[0-9A-Za-z]\\)*\\'" account-hint) t)
+   (t (user-error "Account hint '%s' contains invalid characters" account-hint))))
+
+;;; Backend and token management helpers
+
+(defun gptel-oauth--get-backends-by (predicate account-hint-accessor account-hint)
+  "Get backends matching PREDICATE with ACCOUNT-HINT-ACCESSOR equal to ACCOUNT-HINT.
+
+PREDICATE is a function that takes a backend and returns t if it matches.
+ACCOUNT-HINT-ACCESSOR is a function that takes a backend and returns its account hint.
+ACCOUNT-HINT is the account hint string to match against."
+  (seq-filter (lambda (b) (and (funcall predicate b)
+                               (string= (funcall account-hint-accessor b) account-hint)))
+              (mapcar #'cdr gptel--known-backends)))
+
+(defun gptel-oauth--generate-token-filename (base-file validator account-hint)
+  "Generate token filename for ACCOUNT-HINT using BASE-FILE and VALIDATOR.
+
+BASE-FILE is the base token filename without account hint suffix.
+VALIDATOR is a function that validates ACCOUNT-HINT and signals an error if invalid.
+ACCOUNT-HINT is the account hint string.
+
+If ACCOUNT-HINT is empty, returns BASE-FILE.
+Otherwise, returns BASE-FILE with '_' and ACCOUNT-HINT appended."
+  (funcall validator account-hint)
+  (if (= (length account-hint) 0)
+      base-file
+    (concat base-file "_" account-hint)))
+
+(defun gptel-oauth--restore-token-from-file (filename-fn account-hint)
+  "Restore token using FILENAME-FN to generate filename from ACCOUNT-HINT.
+
+FILENAME-FN is a function that takes ACCOUNT-HINT and returns a filename.
+Returns the token plist from the file, or nil if file doesn't exist."
+  (gptel-oauth--read-token (funcall filename-fn account-hint)))
+
+(defun gptel-oauth--save-token-to-file (filename-fn account-hint token)
+  "Save TOKEN using FILENAME-FN to generate filename from ACCOUNT-HINT.
+
+FILENAME-FN is a function that takes ACCOUNT-HINT and returns a filename.
+TOKEN is the token plist to save."
+  (gptel-oauth--write-token (funcall filename-fn account-hint) token))
+
+(defun gptel-oauth--load-token (predicate account-hint-accessor token-getter token-setter
+                                          load-function account-hint)
+  "Load token using custom LOAD-FUNCTION, with propagation to matching backends.
+
+PREDICATE is a function to identify backend type.
+ACCOUNT-HINT-ACCESSOR extracts account hint from a backend.
+TOKEN-GETTER is a function that takes a backend and returns its token.
+TOKEN-SETTER is a function that takes a backend and a token and sets the backend's token.
+LOAD-FUNCTION is the customizable function to load token from storage.
+ACCOUNT-HINT is the account hint for this load operation.
+
+Returns the token plist, or nil if no token found.
+If a cached token exists in gptel-backend, returns that immediately.
+Otherwise, loads via LOAD-FUNCTION and propagates to all backends
+matching PREDICATE and ACCOUNT-HINT."
+  (if-let* ((backend gptel-backend)
+             ((funcall predicate backend))
+             (cached-token (funcall token-getter backend)))
+      cached-token
+    (let ((token (funcall load-function account-hint)))
+      (if (string= token "")
+          ;; Empty string means no data
+          nil
+        ;; Propagate to all matching backends
+        (dolist (b (gptel-oauth--get-backends-by predicate account-hint-accessor account-hint) token)
+          (funcall token-setter b token))))))
+
+(defun gptel-oauth--save-token (predicate account-hint-accessor token-setter
+                                     save-function account-hint token)
+  "Save TOKEN for ACCOUNT-HINT, with propagation to matching backends.
+
+PREDICATE is a function to identify backend type.
+ACCOUNT-HINT-ACCESSOR extracts account hint from a backend.
+TOKEN-SETTER is a function that takes a backend and a token and sets the backend's token.
+SAVE-FUNCTION is the customizable function to save token to storage.
+ACCOUNT-HINT is the account hint to save token for.
+TOKEN is the token plist to save.
+
+Updates token on all backends matching PREDICATE and ACCOUNT-HINT,
+then calls SAVE-FUNCTION."
+  (dolist (b (gptel-oauth--get-backends-by predicate account-hint-accessor account-hint))
+    (funcall token-setter b token))
+  (funcall save-function account-hint token))
+
+(defun gptel-oauth--get-registered-account-hints (predicate account-hint-accessor default-placeholder)
+  "Get list of registered account hints from backends matching PREDICATE.
+
+PREDICATE is a function that takes a backend and returns t if it matches.
+ACCOUNT-HINT-ACCESSOR is a function that extracts the account hint from a backend.
+DEFAULT-PLACEHOLDER is the string to use for backends with empty account hints.
+
+Returns a list of unique account hint strings, or nil if no matching backends exist.
+Empty account hints are replaced with DEFAULT-PLACEHOLDER."
+  (when-let* ((backends (seq-filter predicate (mapcar #'cdr gptel--known-backends)))
+             (account-hints (mapcar
+                             (lambda (b)
+                               (let ((hint (funcall account-hint-accessor b)))
+                                 (if (string= hint "")
+                                     default-placeholder
+                                   hint)))
+                             backends)))
+    (seq-uniq account-hints)))
+
+(defun gptel-oauth--read-account-hint (predicate account-hint-accessor prompt-text default-placeholder &optional error-msg)
+  "Interactively read an account hint for login.
+
+PREDICATE is a function to identify backend type.
+ACCOUNT-HINT-ACCESSOR extracts account hint from a backend.
+PROMPT-TEXT is the text to display when prompting user to choose.
+DEFAULT-PLACEHOLDER is the string used to represent the default account.
+ERROR-MSG is an optional error message to display when no backends are registered.
+
+Returns the selected account hint as a string, with DEFAULT-PLACEHOLDER
+converted to empty string."
+  (let* ((known-account-hints (or (gptel-oauth--get-registered-account-hints
+                                   predicate account-hint-accessor default-placeholder)
+                                '()))
+         (chosen-account-hint (cond
+                              ((= 0 (length known-account-hints))
+                               (user-error (or error-msg
+                                           "No backends registered")))
+                              ((= 1 (length known-account-hints))
+                               (car known-account-hints))
+                              (t
+                               (completing-read prompt-text
+                                                known-account-hints nil t)))))
+    (if (string= chosen-account-hint default-placeholder)
+        ""
+      chosen-account-hint)))
 
 ;;; URL / JWT helpers
 

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -231,7 +231,7 @@ matching PREDICATE and ACCOUNT-HINT."
           (funcall token-setter b token))))))
 
 (defun gptel-oauth--save-token (predicate account-hint-accessor token-setter
-                                     save-function account-hint token)
+                                          save-function account-hint token)
   "Save TOKEN for ACCOUNT-HINT, with propagation to matching backends.
 
 PREDICATE is a function to identify backend type.
@@ -257,13 +257,13 @@ DEFAULT-PLACEHOLDER is the string to use for backends with empty account hints.
 Returns a list of unique account hint strings, or nil if no matching backends exist.
 Empty account hints are replaced with DEFAULT-PLACEHOLDER."
   (when-let* ((backends (seq-filter predicate (mapcar #'cdr gptel--known-backends)))
-             (account-hints (mapcar
-                             (lambda (b)
-                               (let ((hint (funcall account-hint-accessor b)))
-                                 (if (string= hint "")
-                                     default-placeholder
-                                   hint)))
-                             backends)))
+              (account-hints (mapcar
+                              (lambda (b)
+                                (let ((hint (funcall account-hint-accessor b)))
+                                  (if (string= hint "")
+                                      default-placeholder
+                                    hint)))
+                              backends)))
     (seq-uniq account-hints)))
 
 (defun gptel-oauth--read-account-hint (predicate account-hint-accessor prompt-text default-placeholder &optional error-msg)
@@ -279,16 +279,16 @@ Returns the selected account hint as a string, with DEFAULT-PLACEHOLDER
 converted to empty string."
   (let* ((known-account-hints (or (gptel-oauth--get-registered-account-hints
                                    predicate account-hint-accessor default-placeholder)
-                                '()))
+                                  '()))
          (chosen-account-hint (cond
-                              ((= 0 (length known-account-hints))
-                               (user-error (or error-msg
-                                           "No backends registered")))
-                              ((= 1 (length known-account-hints))
-                               (car known-account-hints))
-                              (t
-                               (completing-read prompt-text
-                                                known-account-hints nil t)))))
+                               ((= 0 (length known-account-hints))
+                                (user-error (or error-msg
+                                                "No backends registered")))
+                               ((= 1 (length known-account-hints))
+                                (car known-account-hints))
+                               (t
+                                (completing-read prompt-text
+                                                 known-account-hints nil t)))))
     (if (string= chosen-account-hint default-placeholder)
         ""
       chosen-account-hint)))

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -179,16 +179,15 @@ ACCOUNT-HINT is the account hint string to match against."
                                (string= (funcall account-hint-accessor b) account-hint)))
               (mapcar #'cdr gptel--known-backends)))
 
-(defun gptel-oauth--generate-token-filename (base-file validator account-hint)
-  "Generate token filename for ACCOUNT-HINT using BASE-FILE and VALIDATOR.
+(defun gptel-oauth--generate-token-filename (base-file account-hint)
+  "Generate token filename for ACCOUNT-HINT using BASE-FILE.
 
 BASE-FILE is the base token filename without account hint suffix.
-VALIDATOR is a function that validates ACCOUNT-HINT and signals an error if invalid.
 ACCOUNT-HINT is the account hint string.
 
 If ACCOUNT-HINT is empty, returns BASE-FILE.
 Otherwise, returns BASE-FILE with '_' and ACCOUNT-HINT appended."
-  (funcall validator account-hint)
+  (gptel-oauth--validate-account-hint account-hint)
   (if (= (length account-hint) 0)
       base-file
     (concat base-file "_" account-hint)))

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -206,8 +206,8 @@ If a cached token exists in gptel-backend, returns that immediately.
 Otherwise, loads via LOAD-FUNCTION and propagates to all backends
 matching PREDICATE and ACCOUNT-HINT."
   (if-let* ((backend gptel-backend)
-             ((funcall predicate backend))
-             (cached-token (funcall token-getter backend)))
+            ((funcall predicate backend))
+            (cached-token (funcall token-getter backend)))
       cached-token
     (let ((token (funcall load-function account-hint)))
       (when (and token (not (equal token "")))

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -193,13 +193,6 @@ Otherwise, returns BASE-FILE with '_' and ACCOUNT-HINT appended."
       base-file
     (concat base-file "_" account-hint)))
 
-(defun gptel-oauth--save-token-to-file (filename-fn account-hint token)
-  "Save TOKEN using FILENAME-FN to generate filename from ACCOUNT-HINT.
-
-FILENAME-FN is a function that takes ACCOUNT-HINT and returns a filename.
-TOKEN is the token plist to save."
-  (gptel-oauth--write-token (funcall filename-fn account-hint) token))
-
 (defun gptel-oauth--load-token (predicate account-hint-accessor token-getter token-setter
                                           load-function account-hint)
   "Load token using custom LOAD-FUNCTION, with propagation to matching backends.

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -63,15 +63,19 @@ Returns nil if FILE does not exist or cannot be read."
 (defcustom gptel-oauth-token-load-function nil
   "Function to load OAuth tokens.
 Default is nil, meaning use backend-specific defaults.
-When set, this function is called with ACCOUNT-HINT and should return
-the token plist or nil.  Backends can customize this before use."
+When set, this function is called with BACKEND-TYPE and ACCOUNT-HINT
+and should return the token plist or nil.  BACKEND-TYPE is a symbol
+indicating which OAuth backend (e.g., 'gptel-gh, 'gptel-openai-oauth).
+Backends can customize this before use."
   :type '(or null function)
   :group 'gptel)
 
 (defcustom gptel-oauth-token-save-function nil
   "Function to save OAuth tokens.
 Default is nil, meaning use backend-specific defaults.
-When set, this function is called with ACCOUNT-HINT and TOKEN."
+When set, this function is called with BACKEND-TYPE, ACCOUNT-HINT and TOKEN.
+BACKEND-TYPE is a symbol indicating which OAuth backend (e.g., 'gptel-gh,
+'gptel-openai-oauth)."
   :type '(or null function)
   :group 'gptel)
 

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -193,13 +193,6 @@ Otherwise, returns BASE-FILE with '_' and ACCOUNT-HINT appended."
       base-file
     (concat base-file "_" account-hint)))
 
-(defun gptel-oauth--restore-token-from-file (filename-fn account-hint)
-  "Restore token using FILENAME-FN to generate filename from ACCOUNT-HINT.
-
-FILENAME-FN is a function that takes ACCOUNT-HINT and returns a filename.
-Returns the token plist from the file, or nil if file doesn't exist."
-  (gptel-oauth--read-token (funcall filename-fn account-hint)))
-
 (defun gptel-oauth--save-token-to-file (filename-fn account-hint token)
   "Save TOKEN using FILENAME-FN to generate filename from ACCOUNT-HINT.
 

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -227,9 +227,7 @@ matching PREDICATE and ACCOUNT-HINT."
              (cached-token (funcall token-getter backend)))
       cached-token
     (let ((token (funcall load-function account-hint)))
-      (if (string= token "")
-          ;; Empty string means no data
-          nil
+      (when (and token (not (equal token "")))
         ;; Propagate to all matching backends
         (dolist (b (gptel-oauth--get-backends-by predicate account-hint-accessor account-hint) token)
           (funcall token-setter b token))))))

--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -62,7 +62,7 @@ Returns nil if FILE does not exist or cannot be read."
   "Function to load OAuth tokens.
 Default is nil, meaning use backend-specific defaults.
 When set, this function is called with BACKEND-TYPE and ACCOUNT-HINT
-and should return the token plist or nil.  BACKEND-TYPE is a symbol
+and should return the token or nil.  BACKEND-TYPE is a symbol
 indicating which OAuth backend (e.g., 'gptel-gh, 'gptel-openai-oauth).
 Backends can customize this before use."
   :type '(or null function)
@@ -201,7 +201,7 @@ TOKEN-SETTER is a function that takes a backend and a token and sets the backend
 LOAD-FUNCTION is the customizable function to load token from storage.
 ACCOUNT-HINT is the account hint for this load operation.
 
-Returns the token plist, or nil if no token found.
+Returns the token or nil if no token found.
 If a cached token exists in gptel-backend, returns that immediately.
 Otherwise, loads via LOAD-FUNCTION and propagates to all backends
 matching PREDICATE and ACCOUNT-HINT."
@@ -224,7 +224,7 @@ ACCOUNT-HINT-ACCESSOR extracts account hint from a backend.
 TOKEN-SETTER is a function that takes a backend and a token and sets the backend's token.
 SAVE-FUNCTION is the customizable function to save token to storage.
 ACCOUNT-HINT is the account hint to save token for.
-TOKEN is the token plist to save.
+TOKEN is the token to save.
 
 Updates token on all backends matching PREDICATE and ACCOUNT-HINT,
 then calls SAVE-FUNCTION."

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -414,7 +414,7 @@ Returns t if TOKEN is a valid plist containing :access_token,
 (defun gptel-openai-oauth--get-load-token-function (account-hint)
   "Load OpenAI OAuth token from file, ensuring it is a valid plist."
   (let ((token (if #'gptel-oauth-token-load-function
-                  (gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
+                  (funcall gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
                 (gptel-oauth--read-token (gptel--openai-oauth-generate-token-filename account-hint)))))
     ;; Filter out nil and empty values (empty files do not contain tokens)
     (when (and token (not (equal token "")))
@@ -438,7 +438,7 @@ Returns t if TOKEN is a valid plist containing :access_token,
   (unless (gptel--openai-oauth-validate-token-p token)
     (user-error "Cannot save invalid OpenAI OAuth token: expected plist with all required fields, got %S" token))
   (if #'gptel-oauth-token-save-function
-      (gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
+      (funcall gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
     (gptel-oauth--write-token (gptel--openai-oauth-generate-token-filename account-hint) token)))
 
 ;;;; Oauth backend management

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -390,10 +390,6 @@ reauthenticate as needed."
    #'gptel-oauth--validate-account-hint
    account-hint))
 
-(defun gptel--openai-oauth-restore-token-from-file (account-hint)
-  "Restore OpenAI OAuth token from file using ACCOUNT-HINT."
-  (gptel-oauth--restore-token-from-file #'gptel--openai-oauth-generate-token-filename account-hint))
-
 (defun gptel--openai-oauth-save-token-to-file (account-hint token)
   "Save OpenAI OAuth TOKEN to file using ACCOUNT-HINT."
   (gptel-oauth--save-token-to-file #'gptel--openai-oauth-generate-token-filename account-hint token))
@@ -411,7 +407,7 @@ reauthenticate as needed."
 (defun gptel-openai-oauth--get-load-token-function (account-hint)
   (if #'gptel-oauth-token-load-function
       (gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
-    (gptel--openai-oauth-restore-token-from-file account-hint))))
+    (gptel-oauth--read-token (gptel--openai-oauth-generate-token-filename account-hint))))
 
 (defun gptel--openai-oauth-save-token (account-hint token)
   "Save OpenAI OAuth token using customizable save function."

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -389,6 +389,18 @@ reauthenticate as needed."
    gptel--openai-oauth-token-file
    account-hint))
 
+(defun gptel--openai-oauth-validate-token-p (token)
+  "Check if OpenAI OAuth TOKEN is valid.
+
+Returns t if TOKEN is a valid plist containing :access_token,
+:refresh_token, :expires_at, and :id_token."
+  (and token
+       (plistp token)
+       (plist-member token :access_token)
+       (plist-member token :refresh_token)
+       (plist-member token :expires_at)
+       (plist-member token :id_token)))
+
 (defun gptel--openai-oauth-load-token (account-hint)
   "Load OpenAI OAuth token using customizable load function."
   (gptel-oauth--load-token
@@ -400,9 +412,16 @@ reauthenticate as needed."
    account-hint))
 
 (defun gptel-openai-oauth--get-load-token-function (account-hint)
-  (if #'gptel-oauth-token-load-function
-      (gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
-    (gptel-oauth--read-token (gptel--openai-oauth-generate-token-filename account-hint))))
+  "Load OpenAI OAuth token from file, ensuring it is a valid plist."
+  (let ((token (if #'gptel-oauth-token-load-function
+                  (gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
+                (gptel-oauth--read-token (gptel--openai-oauth-generate-token-filename account-hint)))))
+    ;; Filter out nil and empty values (empty files do not contain tokens)
+    (when (and token (not (equal token "")))
+      (unless (gptel--openai-oauth-validate-token-p token)
+        (message "Ignoring invalid OpenAI OAuth token format in file: missing required fields, got %S" token)
+        (setq token nil))
+      token)))
 
 (defun gptel--openai-oauth-save-token (account-hint token)
   "Save OpenAI OAuth token using customizable save function."
@@ -415,6 +434,9 @@ reauthenticate as needed."
    token))
 
 (defun gptel-openai-oauth--get-save-token-function (account-hint token)
+  "Save OpenAI OAuth TOKEN to file for ACCOUNT-HINT, ensuring it is a valid plist."
+  (unless (gptel--openai-oauth-validate-token-p token)
+    (user-error "Cannot save invalid OpenAI OAuth token: expected plist with all required fields, got %S" token))
   (if #'gptel-oauth-token-save-function
       (gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
     (gptel-oauth--write-token (gptel--openai-oauth-generate-token-filename account-hint) token)))

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -390,10 +390,6 @@ reauthenticate as needed."
    #'gptel-oauth--validate-account-hint
    account-hint))
 
-(defun gptel--openai-oauth-save-token-to-file (account-hint token)
-  "Save OpenAI OAuth TOKEN to file using ACCOUNT-HINT."
-  (gptel-oauth--save-token-to-file #'gptel--openai-oauth-generate-token-filename account-hint token))
-
 (defun gptel--openai-oauth-load-token (account-hint)
   "Load OpenAI OAuth token using customizable load function."
   (gptel-oauth--load-token
@@ -422,7 +418,7 @@ reauthenticate as needed."
 (defun gptel-openai-oauth--get-save-token-function (account-hint token)
   (if #'gptel-oauth-token-save-function
       (gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
-    (gptel--openai-oauth-save-token-to-file account-hint token)))
+    (gptel-oauth--write-token (gptel--openai-oauth-generate-token-filename account-hint) token)))
 
 ;;;; Oauth backend management
 

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -405,8 +405,13 @@ reauthenticate as needed."
    #'gptel-openai-oauth-account-hint
    #'gptel-openai-oauth-token
    (lambda (b token) (setf (gptel-openai-oauth-token b) token))
-   (or gptel-oauth-token-load-function 'gptel--openai-oauth-restore-token-from-file)
-   account-hint)))
+   #'gptel-openai-oauth--get-load-token-function
+   account-hint))
+
+(defun gptel-openai-oauth--get-load-token-function (account-hint)
+  (if #'gptel-oauth-token-load-function
+      (gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
+    (gptel--openai-oauth-restore-token-from-file account-hint))))
 
 (defun gptel--openai-oauth-save-token (account-hint token)
   "Save OpenAI OAuth token using customizable save function."
@@ -414,9 +419,14 @@ reauthenticate as needed."
    #'gptel-openai-oauth-p
    #'gptel-openai-oauth-account-hint
    (lambda (b token) (setf (gptel-openai-oauth-token b) token))
-   (or gptel-oauth-token-save-function 'gptel--openai-oauth-save-token-to-file)
+   #'gptel-openai-oauth--get-save-token-function
    account-hint
    token))
+
+(defun gptel-openai-oauth--get-save-token-function (account-hint token)
+  (if #'gptel-oauth-token-save-function
+      (gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
+    (gptel--openai-oauth-save-token-to-file account-hint token)))
 
 ;;;; Oauth backend management
 

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -413,7 +413,7 @@ Returns t if TOKEN is a valid plist containing :access_token,
 
 (defun gptel-openai-oauth--get-load-token-function (account-hint)
   "Load OpenAI OAuth token from file, ensuring it is a valid plist."
-  (let ((token (if #'gptel-oauth-token-load-function
+  (let ((token (if gptel-oauth-token-load-function
                   (funcall gptel-oauth-token-load-function 'gptel-openai-oauth account-hint)
                 (gptel-oauth--read-token (gptel--openai-oauth-generate-token-filename account-hint)))))
     ;; Filter out nil and empty values (empty files do not contain tokens)
@@ -437,7 +437,7 @@ Returns t if TOKEN is a valid plist containing :access_token,
   "Save OpenAI OAuth TOKEN to file for ACCOUNT-HINT, ensuring it is a valid plist."
   (unless (gptel--openai-oauth-validate-token-p token)
     (user-error "Cannot save invalid OpenAI OAuth token: expected plist with all required fields, got %S" token))
-  (if #'gptel-oauth-token-save-function
+  (if gptel-oauth-token-save-function
       (funcall gptel-oauth-token-save-function 'gptel-openai-oauth account-hint token)
     (gptel-oauth--write-token (gptel--openai-oauth-generate-token-filename account-hint) token)))
 

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -53,7 +53,8 @@ Device Authorization Grant."
 (cl-defstruct (gptel-openai-oauth (:constructor gptel--make-openai-oauth)
                                   (:copier nil)
                                   (:include gptel-openai-responses))
-  token)
+  token
+  account-hint)
 
 (cl-defmethod gptel--request-data ((_backend gptel-openai-oauth) _prompts)
   "Return request data for the OpenAI OAuth backend.
@@ -291,41 +292,39 @@ If your browser does not open automatically, browse to %s: "
 
 ;;;; OpenAI Oauth login and token handling
 
-(defun gptel--openai-oauth-default-backend ()
-  "Return the current or first registered OpenAI OAuth backend."
-  (cond
-   ((gptel-openai-oauth-p gptel-backend)
-    gptel-backend)
-   ((cdr (cl-find-if #'gptel-openai-oauth-p gptel--known-backends
-                     :key #'cdr)))
-   (t (user-error "No OpenAI OAuth backend found.  \
-Please set one up with `gptel-make-openai-oauth' first"))))
+(defun gptel-openai-oauth-login (&optional account-hint method)
+  "Authenticate using the OpenAI device flow for ACCOUNT-HINT.
 
-(defun gptel-openai-oauth-login (&optional backend method)
-  "Authenticate BACKEND using OpenAI OAuth.
-
-If BACKEND is nil, use `gptel-backend' when it is an OpenAI OAuth
-backend, otherwise use the first registered OpenAI OAuth backend.
+If ACCOUNT-HINT is nil, use the default account.  Interactively, prompt
+for an account hint from registered backends.
 METHOD can be `authorization-code' for OAuth 2.0 Authorization
 Code Flow with PKCE or `device' for OAuth 2.0 Device
 Authorization Grant.  If METHOD is nil, use
 `gptel-openai-oauth-login-method'."
-  (interactive (list (gptel--openai-oauth-default-backend)))
-  (unless backend (setq backend (gptel--openai-oauth-default-backend)))
-  (unless (gptel-openai-oauth-p backend)
-    (user-error "%s is not an OpenAI OAuth backend" (gptel-backend-name backend)))
-  (let ((token-plist
-         (pcase (or method gptel-openai-oauth-login-method)
-           ('authorization-code
-            (gptel--openai-oauth-login-with-authorization-code backend))
-           ('device
-            (gptel--openai-oauth-login-with-device-code backend))
-           (login-method
-            (user-error "Unknown OpenAI OAuth login method: %S" login-method)))))
-    (when (and (called-interactively-p 'interactive)
-               (plist-get token-plist :access_token))
-      (message "Successfully logged in to OpenAI OAuth."))
-    token-plist))
+  (interactive (list
+                (gptel-oauth--read-account-hint
+                 #'gptel-openai-oauth-p #'gptel-openai-oauth-account-hint
+                 "Choose OpenAI account: "
+                 "[Default account]"
+                 "No OpenAI OAuth backends registered.  \
+Please set one up with `gptel-make-openai-oauth' first")))
+  (let ((oauth-backends (gptel--openai-oauth-get-backends-by-account-hint account-hint)))
+    ;; It shall only be possible to login when there exists a corresponding backend
+    (unless oauth-backends
+      (user-error "No OpenAI OAuth backend found for account hint '%s'" account-hint))
+    (let* ((backend (car oauth-backends))
+           (token-plist
+            (pcase (or method gptel-openai-oauth-login-method)
+              ('authorization-code
+               (gptel--openai-oauth-login-with-authorization-code backend))
+              ('device
+               (gptel--openai-oauth-login-with-device-code backend))
+              (login-method
+               (user-error "Unknown OpenAI OAuth login method: %S" login-method)))))
+      (when (and (called-interactively-p 'interactive)
+                 (plist-get token-plist :access_token))
+        (message "Successfully logged in to OpenAI OAuth."))
+      token-plist)))
 
 (defun gptel--openai-oauth-persist (backend token-plist)
   "Persist TOKEN-PLIST for BACKEND.
@@ -341,7 +340,7 @@ it in BACKEND."
                  :access_token access_token
                  :refresh_token refresh_token
                  :id_token (gptel-oauth--jwt-payload id_token))))
-      (gptel-oauth--write-token gptel--openai-oauth-token-file token-processed)
+      (gptel--openai-oauth-save-token (gptel-openai-oauth-account-hint backend) token-processed)
       (setf (gptel-openai-oauth-token backend) token-processed)
       token-plist)))
 
@@ -366,10 +365,10 @@ If BACKEND is nil, use `gptel-backend'.  Restore, refresh, or
 reauthenticate as needed."
   (unless backend (setq backend gptel-backend))
   (unless (gptel-openai-oauth-token backend)
-    (if-let* ((token-plist (gptel-oauth--read-token
-                            gptel--openai-oauth-token-file)))
-        (setf (gptel-openai-oauth-token backend) token-plist)
-      (gptel-openai-oauth-login backend)))
+    (let ((account-hint (gptel-openai-oauth-account-hint backend)))
+      (if-let* ((token-plist (gptel--openai-oauth-load-token account-hint)))
+          (setf (gptel-openai-oauth-token backend) token-plist)
+        (gptel-openai-oauth-login account-hint))))
   
   (let ((token-plist (gptel-openai-oauth-token backend)))
     (if-let* ((expiry (plist-get token-plist :expires_at))
@@ -378,7 +377,46 @@ reauthenticate as needed."
         t
       (if-let* ((refresh (plist-get token-plist :refresh_token)))
           (gptel--openai-oauth-refresh backend refresh)
-        (gptel-openai-oauth-login backend)))))
+        (gptel-openai-oauth-login (gptel-openai-oauth-account-hint backend)))))
+
+(defun gptel--openai-oauth-get-backends-by-account-hint (account-hint)
+  "Get all OpenAI OAuth backends for a specific account hint."
+  (gptel-oauth--get-backends-by #'gptel-openai-oauth-p #'gptel-openai-oauth-account-hint account-hint))
+
+(defun gptel--openai-oauth-generate-token-filename (account-hint)
+  "Generate token filename for OpenAI OAuth backend with ACCOUNT-HINT."
+  (gptel-oauth--generate-token-filename
+   gptel--openai-oauth-token-file
+   #'gptel-oauth--validate-account-hint
+   account-hint))
+
+(defun gptel--openai-oauth-restore-token-from-file (account-hint)
+  "Restore OpenAI OAuth token from file using ACCOUNT-HINT."
+  (gptel-oauth--restore-token-from-file #'gptel--openai-oauth-generate-token-filename account-hint))
+
+(defun gptel--openai-oauth-save-token-to-file (account-hint token)
+  "Save OpenAI OAuth TOKEN to file using ACCOUNT-HINT."
+  (gptel-oauth--save-token-to-file #'gptel--openai-oauth-generate-token-filename account-hint token))
+
+(defun gptel--openai-oauth-load-token (account-hint)
+  "Load OpenAI OAuth token using customizable load function."
+  (gptel-oauth--load-token
+   #'gptel-openai-oauth-p
+   #'gptel-openai-oauth-account-hint
+   #'gptel-openai-oauth-token
+   (lambda (b token) (setf (gptel-openai-oauth-token b) token))
+   (or gptel-oauth-token-load-function 'gptel--openai-oauth-restore-token-from-file)
+   account-hint)))
+
+(defun gptel--openai-oauth-save-token (account-hint token)
+  "Save OpenAI OAuth token using customizable save function."
+  (gptel-oauth--save-token
+   #'gptel-openai-oauth-p
+   #'gptel-openai-oauth-account-hint
+   (lambda (b token) (setf (gptel-openai-oauth-token b) token))
+   (or gptel-oauth-token-save-function 'gptel--openai-oauth-save-token-to-file)
+   account-hint
+   token))
 
 ;;;; Oauth backend management
 
@@ -409,6 +447,7 @@ before constructing the headers."
           (host "chatgpt.com")
           (protocol "https")
           (endpoint "/backend-api/codex/responses")
+          (account-hint "")
           (models
            '( gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini
               gpt-5.4 gpt-5.5 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna)))
@@ -418,8 +457,15 @@ This backend uses ChatGPT OAuth tokens (not OpenAI API keys) and
 targets the Codex endpoint on chatgpt.com.  Run
 `gptel-openai-oauth-login' once to authenticate.
 
-For keyword argument meanings, see `gptel-make-openai'."
+Keyword arguments:
+
+ACCOUNT-HINT (optional) is an indicator of which OpenAI account to associate
+the backend with. This enables backends to be logged in as a separate user. Note
+that this is only a hint and will be used when a token is saved/loaded.
+
+For other keyword argument meanings, see `gptel-make-openai'."
   (declare (indent 1))
+  (gptel-oauth--validate-account-hint account-hint)
   (let ((backend (gptel--make-openai-oauth
                   :curl-args curl-args
                   :name name
@@ -431,6 +477,7 @@ For keyword argument meanings, see `gptel-make-openai'."
                   :endpoint endpoint
                   :stream stream
                   :request-params request-params
+                  :account-hint account-hint
                   :url (if protocol
                            (concat protocol "://" host endpoint)
                          (concat host endpoint)))))

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -387,7 +387,6 @@ reauthenticate as needed."
   "Generate token filename for OpenAI OAuth backend with ACCOUNT-HINT."
   (gptel-oauth--generate-token-filename
    gptel--openai-oauth-token-file
-   #'gptel-oauth--validate-account-hint
    account-hint))
 
 (defun gptel--openai-oauth-load-token (account-hint)

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -377,7 +377,7 @@ reauthenticate as needed."
         t
       (if-let* ((refresh (plist-get token-plist :refresh_token)))
           (gptel--openai-oauth-refresh backend refresh)
-        (gptel-openai-oauth-login (gptel-openai-oauth-account-hint backend)))))
+        (gptel-openai-oauth-login (gptel-openai-oauth-account-hint backend))))))
 
 (defun gptel--openai-oauth-get-backends-by-account-hint (account-hint)
   "Get all OpenAI OAuth backends for a specific account hint."


### PR DESCRIPTION
Introduce functions that can be overloaded that controls how a token is restored/stored. This enables the user to make gptel-gh store the token in a secure manner, similar to what is recommended for the other backend variants.

In conjunction with this, proper support for multiple accounts has also been introduced by having each gptel-gh backend be marked with which account they should be considered to belong to.


**Old description:**
Removed the file based persistent storage of the tokens, as they were stored in clear text. They will only be stored in variables.

The initial value of the github-token can now be set by providing a function that provides it. This enables this token to be securely stored outside of Emacs.