### PR TITLE
gptel-gh: add grok-code-fast-1 model

### DIFF
--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -159,7 +159,13 @@
      :context-window 1000
      :input-cost 0.10
      :output-cost 0.40
-     :cutoff-date "2024-08")))
+     :cutoff-date "2024-08")
+    (grok-code-fast-1
+     :description "Fast reasoning model for agentic coding"
+     :capabilities '(tool-use json reasoning)
+     :context-window 128
+     :input-cost 0.2
+     :output-cost 1.5)))
 
 (cl-defstruct (gptel--gh (:include gptel-openai)
                          (:copier nil)


### PR DESCRIPTION
Reuse properties defined in gptel-openai-extras but update context-window to 128, as returned by the Copilot Models API