### PR TITLE
add kagi api key to request headers

### DIFF
--- a/gptel-kagi.el
+++ b/gptel-kagi.el
@@ -121,7 +121,7 @@
 (cl-defun gptel-make-kagi
     (name &key curl-args stream key
           (host "kagi.com")
-          (header (lambda () `(("Authorization" . ,(concat "Bot " (gptel--get-api-key))))))
+          (header (lambda () `(("Authorization" . ,(concat "Bot " (gptel--get-api-key key))))))
           (models '((fastgpt :capabilities (nosystem))
                     (summarize:cecil :capabilities (nosystem))
                     (summarize:agnes :capabilities (nosystem))


### PR DESCRIPTION
The key needs to be passed on from `gptel-make-kagi`.