### PR TITLE
Fix attachment link resolution with org-attach ID-based storage

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -41,6 +41,7 @@
 (defvar org-link-angle-re)
 (defvar org-link-bracket-re)
 (declare-function mailcap-file-name-to-mime-type "mailcap")
+(declare-function org-attach-expand "org-attach")
 (declare-function gptel--model-capable-p "gptel")
 (declare-function gptel--model-mime-capable-p "gptel")
 (declare-function gptel--model-name "gptel")
@@ -365,8 +366,11 @@ for inclusion into the user prompt for the gptel request."
         (when-let* ((link (org-element-context))
                     ((gptel-org--link-standalone-p link))
                     (raw-link (org-element-property :raw-link link))
-                    (path (org-element-property :path link))
+                    (raw-path (org-element-property :path link))
                     (type (org-element-property :type link))
+                    (path (if (string= type "attachment")
+                              (org-attach-expand raw-path)
+                            raw-path))
                     ;; FIXME This is not a good place to check for url capability!
                     ((member type `("attachment" "file"
                                     ,@(and (gptel--model-capable-p 'url)

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2033,9 +2033,12 @@ Initiate the request when done."
           (save-excursion (goto-char (point-min))
                           (gptel--parse-list-and-insert (cdr directive))))
         (goto-char (point-max))
-        (setq full-prompt (gptel--parse-buffer ;prompt from buffer or explicitly supplied
-                           gptel-backend (and gptel--num-messages-to-send
-                                              (* 2 gptel--num-messages-to-send))))
+        ;; Parse buffer in original buffer context so org-attach-expand can access
+        ;; Org properties (ID, ATTACH_DIR) not present in the temp copy buffer
+        (setq full-prompt (with-current-buffer (plist-get info :buffer)
+                            (gptel--parse-buffer ;prompt from buffer or explicitly supplied
+                             gptel-backend (and gptel--num-messages-to-send
+                                                (* 2 gptel--num-messages-to-send)))))
         ;; Inject media chunks into the first user prompt if required.  Media
         ;; chunks are always included with the first user message,
         ;; irrespective of the preference in `gptel-use-context'.  This is


### PR DESCRIPTION
## Summary

Fixes #1073

This PR fixes an issue where gptel does not correctly locate media files referenced by org-mode "attachment" links when using org-attach's ID-based storage support.

## Changes

### 1. `gptel-org.el` (gptel--parse-media-links)
- Use `org-attach-expand` to properly resolve attachment-type links to their actual file paths
- This is necessary when org-attach uses ID-based storage where attachment directories are not relative to the current file
- Added `declare-function` for `org-attach-expand`

### 2. `gptel-request.el` (gptel--realize-query)
- Call `gptel--parse-buffer` in the original buffer context rather than the temp buffer
- This ensures `org-attach-expand` has access to Org properties (ID, ATTACH_DIR) needed to resolve attachment paths
- These properties are not copied to the temp buffer, so the context switch is necessary

## Testing

- Backward compatible: file-type links continue to work as before
- Attachment-type links now properly expand to absolute paths when using ID-based storage
- Existing test suite validates media link parsing functionality

## Test plan

1. Customize `org-attach-id-dir` to a location outside the working directory
2. Create an Org file with a heading that has an ID property
3. Attach an image file to the heading using `org-attach`
4. Link to the attachment using `[[attachment:filename.png]]`
5. Enable media tracking in gptel
6. Send a query asking about the image
7. Verify the image is correctly encoded and sent to the LLM

Without this fix, the LLM would not receive the image. With the fix, the image is properly encoded and included in the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)