### PR TITLE
Fix gptel-auto-scroll when streaming at end of buffer

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -298,16 +298,19 @@ in any way.")
 
 ;;; Utility functions
 (defun gptel-auto-scroll ()
-  "Scroll window if LLM response continues below viewport.
-
-Note: This will move the cursor."
+  "Follow streaming output by moving point when stream continues off-screen.
+Runs from `gptel-post-stream-hook'. Moves point to the streaming
+insertion position (which is point while this hook runs) and recenters
+the window so that the streaming position appears near the bottom."
   (when-let* ((win (get-buffer-window (current-buffer) 'visible))
-              ((not (pos-visible-in-window-p (point) win)))
-              (scroll-error-top-bottom t))
-    (condition-case nil
-        (with-selected-window win
-          (scroll-up-command))
-      (error nil))))
+              (pos (point)))
+    (unless (pos-visible-in-window-p pos win)
+      (run-at-time 0 nil
+                   (lambda (w p)
+                     (with-selected-window w
+                       (goto-char p)
+                       (recenter -1)))
+                   win pos))))
 
 (defun gptel-beginning-of-response (&optional _ _ arg)
   "Move point to the beginning of the LLM response ARG times."


### PR DESCRIPTION
Fixes #893

## Summary

The `gptel-auto-scroll` function was called from within `save-excursion` during streaming responses. When point was at the end of the buffer, `scroll-up-command` would fail, preventing the window from following streaming output.

## Changes

This fix defers the scroll operation using `run-at-time`, allowing it to execute after `save-excursion` completes. The implementation also:
- Captures the insertion position before deferring (avoiding stale point references)
- Uses `recenter -1` instead of `scroll-up-command` for more reliable positioning at window bottom
- Passes window and position as explicit lambda parameters

## Testing

The fix addresses the reproduction steps in #893:
1. Enable auto scroll: `(add-hook 'gptel-post-stream-hook 'gptel-auto-scroll)`
2. Move cursor to end of buffer
3. Invoke `gptel-send` with text longer than viewport

Expected: Window scrolls to follow streaming text
Result: Window now correctly scrolls

## Comparison to PR #894

This implementation improves on PR #894 by:
- Capturing position before deferring (more robust)
- Using `recenter -1` for consistent bottom-of-window positioning
- Passing parameters explicitly to the lambda (cleaner closure)
- Enhanced documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)