### PR TITLE
gptel-rewrite: Fix directive hook evaluation location

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -708,7 +708,9 @@ generated from functions."
                              "\n\n" (car prompt))))
     (prog1 (gptel-request prompt
              :dry-run dry-run
-             :system gptel--rewrite-directive
+             :system (if (functionp gptel--rewrite-directive)
+                         (funcall gptel--rewrite-directive)
+                       gptel--rewrite-directive)
              :stream gptel-stream
              :context
              (let ((ov (or (cdr-safe (get-char-property-and-overlay (point) 'gptel-rewrite))


### PR DESCRIPTION
The gptel-rewrite-directive-hook was being evaluated in the wrong buffer context, causing (buffer-name) to return "gptel-prompt" instead of the actual buffer name.

The gptel-rewrite menu correctly displayed the prompt generated by the hook, making the issue not apparent during normal usage.

This was discovered while testing gptel-rewrite-ripgrep-edit, where the generic hooks fail to handle the ripgrep-edit format, making the incorrect hook evaluation apparent.

Fixes: 89d1b4768d9a ("gptel: Switch to prompt-buffer centric parsing")