### PR TITLE
Revert "gptel-rewrite: Diff buffers, not files (#731)"

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -354,7 +354,10 @@ BUF is the buffer to modify, defaults to the overlay buffer."
               ((buffer-live-p ov-buf)))
     (require 'diff)
     (let* ((newbuf (gptel--rewrite-prepare-buffer ovs))
-           (diff-buf (diff-no-select ov-buf newbuf switches)))
+           (diff-buf (diff-no-select
+                      (if-let* ((buf-file (buffer-file-name ov-buf)))
+                          (expand-file-name buf-file) ov-buf)
+                      newbuf switches)))
       (with-current-buffer diff-buf
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))


### PR DESCRIPTION
This reverts commit 0ce917a7f091eee7d2148ba53536816106f0a7b0.

The above commit while not wrong per se, prevents to use diff-mode to apply hunks, which makes it not a good tradeoff.