### PR TITLE
Bugfix: additional directive on nil system message

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1782,7 +1782,7 @@ for details."
   (setq full (or full gptel--system-message))
   (cl-typecase full
     (string (concat full "\n\n" additional))
-    (list (let ((copy (copy-sequence full)))
+    (cons (let ((copy (copy-sequence full)))
             (setcar copy (concat (car copy) "\n\n" additional))
             copy))
     (function (lambda () (gptel--merge-additional-directive


### PR DESCRIPTION
Hi,
I noticed an error when trying to call `gptel-send` with no system message set and an instruction set (`d` in the transient menu).
That happens because on `gptel--merge-additional-directive`, `cl-typecase` matches `list` when `full` arg is `nil` (as I suppose is the case when the system message is not set), and then `setcar` raises "Wrong type argument: consp, nil".
Matching `cons` instead should solve the issue as `nil` will not match it, finally going to the otherwise arm as expected. 

Thanks for the consideration,
and as this is my first message in here, I also take the chance to thank you for the great work on this package