### PR TITLE
gptel-context: add file path expansion to prevent duplicates

### DIFF
--- a/gptel-context.el
+++ b/gptel-context.el
@@ -253,11 +253,12 @@ ACTION should be either `add' or `remove'."
 If PATH is a directory, recursively add all files in it.  PATH should be
 readable as text."
   (interactive "fChoose file to add to context: ")
-  (cond ((file-directory-p path)
-         (gptel-context--add-directory path 'add))
-	((gptel--file-binary-p path)
-         (gptel-context--add-binary-file path))
-	(t (gptel-context--add-text-file path))))
+  (let ((path (expand-file-name path)))
+    (cond ((file-directory-p path)
+           (gptel-context--add-directory path 'add))
+          ((gptel--file-binary-p path)
+           (gptel-context--add-binary-file path))
+          (t (gptel-context--add-text-file path)))))
 
 ;;;###autoload (autoload 'gptel-add-file "gptel-context" "Add files to gptel's context." t)
 (defalias 'gptel-add-file #'gptel-context-add-file)


### PR DESCRIPTION
This prevents issues where the same file might be added multiple times due to different path representations (e.g., relative vs absolute paths, or paths with . and .. components).

This resolves an issue where the following gptel-context-move-to-tail function in my init file would add the same file multiple times when the buffer-file-name and the file path in gptel-context differed due to path normalization.

```
(defun gptel-context-move-to-tail ()
  "Move the current buffer's file to the tail of the context."
  (when (and gptel-context
             (member (buffer-file-name) (apply #'append gptel-context)))
    (gptel-context-remove (buffer-file-name))
    (gptel-add-file (buffer-file-name))))
(add-hook 'after-save-hook #'gptel-context-move-to-tail)
(add-hook 'after-revert-hook #'gptel-context-move-to-tail)
```