### PR TITLE
gptel--markdown-validate-link: dont increase 3 to file link extraction if file:// is not presented

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2240,7 +2240,7 @@ first nil value in REST is guaranteed to be correct."
     (if-let* ((path (nth 3 link))
               (prefix (or (string-search "://" path) 0))
               (link-type (if (= prefix 0) "file" (substring path 0 prefix)))
-              (path (if (equal link-type "file")
+              (path (if (and (equal link-type "file") (> prefix 0))
                         (substring path (+ prefix 3)) path))
               (resource-type
                (or (and (equal link-type "file") 'file)


### PR DESCRIPTION
The current logic where we always add `3` even when the `file://` is not there is not working for relative file path, ex: `./asset/a.jpg`