### PR TITLE
gptel-gh: use the host dynamically

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2524,15 +2524,15 @@ INFO contains the request data, TOKEN is a unique identifier."
          (gptel-backend (plist-get info :backend))
          (gptel-model (plist-get info :model))
          (gptel-stream (plist-get info :stream))
-         (url (let ((backend-url (gptel-backend-url gptel-backend)))
-                (if (functionp backend-url)
-                    (funcall backend-url) backend-url)))
-         (data-json (decode-coding-string (gptel--json-encode data) 'utf-8 t))
          (headers
           (append '(("Content-Type" . "application/json"))
                   (when-let* ((header (gptel-backend-header gptel-backend)))
                     (if (functionp header)
                         (funcall header) header)))))
+         (url (let ((backend-url (gptel-backend-url gptel-backend)))
+                (if (functionp backend-url)
+                    (funcall backend-url) backend-url)))
+         (data-json (decode-coding-string (gptel--json-encode data) 'utf-8 t))
     (when gptel-log-level
       (when (eq gptel-log-level 'debug)
         (gptel--log (gptel--json-encode


### PR DESCRIPTION
This allows to use the correct host url that's set in the token, ex: `api.enterprise.githubcopilot.com`