### PR TITLE
Fix context order when confirming changes in context buffer

### DIFF
--- a/gptel-context.el
+++ b/gptel-context.el
@@ -840,7 +840,7 @@ If non-nil, indicates backward movement.")
   ;; FIXME(context): This should run in the buffer from which the context
   ;; inspection buffer was visited.
   ;; Update contexts and revert buffer (#482)
-  (setq gptel-context (gptel-context--collect))
+  (setq gptel-context (nreverse (gptel-context--collect)))
   (gptel-context-quit))
 
 (provide 'gptel-context)


### PR DESCRIPTION
When confirming changes in the gptel context buffer, the context list was being reversed due to how it was collected and stored.