### PR TITLE
gptel-bedrock: add amazon.nova-2-lite-v1 model

### DIFF
--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -544,6 +544,7 @@ Convenient to use with `cl-multiple-value-bind'"
     (claude-3-5-haiku-20241022   . "anthropic.claude-3-5-haiku-20241022-v1:0")
     (claude-3-opus-20240229      . "anthropic.claude-3-opus-20240229-v1:0")
     (claude-3-haiku-20240307     . "anthropic.claude-3-haiku-20240307-v1:0")
+    (nova-2-lite-v1              . "amazon.nova-2-lite-v1:0")
     (mistral-7b                  . "mistral.mistral-7b-instruct-v0:2")
     (mistral-8x7b                . "mistral.mixtral-8x7b-instruct-v0:1")
     (mistral-large-2402          . "mistral.mistral-large-2402-v1:0")


### PR DESCRIPTION
Adding "[Amazon Nova 2 Lite](https://aws.amazon.com/ai/generative-ai/nova/), a fast, cost-effective reasoning model for everyday workloads" which is [priced attractively](https://aws.amazon.com/bedrock/pricing/) compared to eg. Sonnet 4.5

```
					Price per 1,000 input tokens	Price per 1,000 output tokens
Amazon Nova 2 Lite	$0.0003							$0.0025
Claude Sonnet 4.5	$0.003							$0.015
```