### PR TITLE
Move post-request hook before sentinel creation

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1657,6 +1657,7 @@ MACHINE is an instance of `gptel-fsm'"
   ;; Reset some flags in info.  This is necessary when reusing fsm's context for
   ;; a second network request: gptel tests for the presence of these flags to
   ;; handle state transitions.  (NOTE: Don't add :token to this.)
+  (run-hooks 'gptel-post-request-hook)
   (let ((info (gptel-fsm-info fsm)))
     (dolist (key '(:tool-success :tool-use :error :http-status :reasoning))
       (when (plist-get info key)
@@ -1665,8 +1666,7 @@ MACHINE is an instance of `gptel-fsm'"
    (if gptel-use-curl
        #'gptel-curl-get-response
      #'gptel--url-get-response)
-   fsm)
-  (run-hooks 'gptel-post-request-hook))
+   fsm))
 
 (defun gptel--handle-tool-use (fsm)
   "Run tool calls captured in FSM, and advance the state machine with the results."


### PR DESCRIPTION
The gptel-post-request-hook is run after the process sentinel has been created. If this hook aborts a running background request (e.g., a kvcache preloading task) using gptel-abort, it can interfere with the new request's setup, causing a "Search failed" error when the new request tries to access the FSM state.

This change ensures the post-request hook runs before the process sentinel is created, preventing interference between concurrent requests and avoiding the "Search failed" error when aborting background tasks.

The error message observed was:

```
------  kvcache speculative prelaoding started by timer ------
Querying ryzen...
Wrote /tmp/gptel-curl-datadgs2S0.json
------  gptel-post-request-hook calls gptel-abort to stop preloading ------
Stopped gptel request in buffer "*gptel-context-preload*"
------  real request fails to start ------
Querying ryzen...
error in process sentinel: save-current-buffer: Search failed: "79f42ff48ff153e47dc3d3dba8020dc6"
error in process sentinel: Search failed: "79f42ff48ff153e47dc3d3dba8020dc6"
```

This is only observed if running a gptel-request in a gptel mode buffer, does not happen if it's gptel-rewrite issuing the gptel-request.