### PR TITLE
Ensure `setter` propagates to parent presets

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2134,7 +2134,7 @@ example) apply the preset buffer-locally."
   (unless setter (setq setter #'set))
   (when-let* ((func (plist-get preset :pre))) (funcall func))
   (when-let* ((parents (plist-get preset :parents)))
-    (mapc #'gptel--apply-preset (ensure-list parents)))
+    (mapc (lambda (parent) (gptel--apply-preset parent setter)) (ensure-list parents)))
   (map-do
    (lambda (key val)
      (pcase key


### PR DESCRIPTION
This fixes an issue where, when e.g. applying a preset buffer-locally, any `:parents` of the preset would still be applied using the default (non-buffer-local) setter.