### PR TITLE
Fix error in `gptel--preset-syms` when using anonymous parent preset

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2209,8 +2209,7 @@ PRESET is the name of a preset, or a spec (plist) of the form
         ((or :description :pre :post))
         (:parents
          (mapc (lambda (parent-preset)
-                 (nconc syms (gptel--preset-syms
-                              (gptel-get-preset parent-preset))))
+                 (nconc syms (gptel--preset-syms parent-preset)))
                (ensure-list val)))
         (:system (push 'gptel--system-message syms))
         (_ (if-let* ((var (or (intern-soft


### PR DESCRIPTION
`gptel--preset-syms` previously always tried to resolve parents using `gptel-get-preset`, which returns nil for anonymous (i.e. plist) parent presets.

This change delegates preset resolution to the top of the recursive call, which correctly only calls `gptel-get-preset` for string/symbol presets.

Here's a simple repro of the issue:

``` emacs-lisp
;; -*- lexical-binding: t; -*-
;;
;; To test use `emacs -q --load [filename]`.
(require 'use-package)
(use-package
 gptel
 :demand t
 ;; Or wherever.
 :load-path "elpaca/repos/gptel")
(let* ((base '(:system "base "))
       (main (list :parents (list base) :system '(:append "main"))))
  ;; Without fix: "gptel preset "nil": Cannot find preset"
  ;; With fix: "base main"
  (gptel-with-preset main (message gptel--system-message)))
```