### PR TITLE
Correctly parse presets with trailing newline.

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2252,7 +2252,7 @@ Before applying the preset, \"@foo\" is removed from the prompt and
 point is placed at its position."
   (when gptel--known-presets
     (text-property-search-backward 'gptel nil t)
-    (while (re-search-forward "@\\([^[:blank:]]+\\)\\_>" nil t)
+    (while (re-search-forward "@\\([^[:space:]]+\\)\\_>" nil t)
       ;; The following convoluted check is because re-search is much faster if
       ;; the search pattern begins with a non-whitespace char.
       (when (or (= (match-beginning 0) (point-min))


### PR DESCRIPTION
`:blank:` doesn't match newlines, so an invocation like:

```
@preset

my prompt
```

was parsing the potential preset as "@preset\n\nmy" rather than "@preset".