### PR TITLE
gptel-rewrite: Fix issues with evil's visual selection mode

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -743,7 +743,7 @@ generated from functions."
       ;; Move back so that the cursor is on the overlay when done.
       (unless (get-char-property (point) 'gptel-rewrite)
         (when (= (point) (region-end)) (run-at-time 0 nil #'backward-char 1)))
-      (deactivate-mark))))
+      (setq deactivate-mark t))))
 
 ;; Allow this to be called non-interactively for dry runs
 (put 'gptel--suffix-rewrite 'interactive-only nil)


### PR DESCRIPTION
Fixes #1062. See commit messages for details.

There are more uses of `(run-at-time 0 ...)` in the code base, but my understanding is that the code they invoke (currently) doesn't call `(region-beginning)` or `(region-end)`, so there's no bad interaction with evil. But perhaps it's a good idea to fix these instances as well to avoid potential future issues, possibly also with other uses of `post-command-hook`.  