### PR TITLE
Fix for github copilot authentication when behind a strict network proxy.

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -884,8 +884,8 @@ MODE-SYM is typically a major-mode symbol."
 (cl-defun gptel--url-retrieve (url &key method data headers)
   "Retrieve URL synchronously with METHOD, DATA and HEADERS."
   (declare (indent 1))
-  (let ((url-request-method (if (eq method'post) "POST" "GET"))
-        (url-request-data (encode-coding-string (gptel--json-encode data) 'utf-8))
+  (let ((url-request-method (if (eq method 'post) "POST" "GET"))
+        (url-request-data (when (eq method 'post) (encode-coding-string (gptel--json-encode data) 'utf-8)))
         (url-mime-accept-string "application/json")
         (url-request-extra-headers
          `(("content-type" . "application/json")


### PR DESCRIPTION
This also aligns with [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1-6) which strongly discourages sending content with a GET request.

```
A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported. An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.
```

* How was this problem discovered? A strict network proxy was returning an error because the HTTP GET request has a body. This meant that we were unable to acquire a session token when trying to use Github Copilot.