### PR TITLE
gptel: prevent tool arguments from interfering with org structure

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -343,8 +343,8 @@ This removal is necessary to avoid auto-mimicry by LLMs."
 
 (defun gptel-org--unescape-tool-results ()
   "Undo escapes done to keep results from escaping blocks.
-Scans backward for gptel tool text property, reads the arguments, then
-unescapes the remainder."
+Scans backward for gptel tool text property, then unescapes the block
+contents."
   (save-excursion
     (goto-char (point-max))
     (let ((prev-pt (point)))
@@ -359,10 +359,6 @@ unescapes the remainder."
             ;; propertized.
             (when (looking-at-p "[[:space:]]*#\\+begin_tool")
               (goto-char (match-end 0)))
-            (condition-case nil
-                (read (current-buffer))
-              ((end-of-file invalid-read-syntax)
-               (message "Could not read tool arguments")))
             ;; TODO this code is able to put the point behind prev-pt, which
             ;; makes the region inverted.  The `max' catches this, but really
             ;; `read' and `looking-at' are the culprits.  Badly formed tool

--- a/gptel.el
+++ b/gptel.el
@@ -1846,7 +1846,7 @@ for tool call results.  INFO contains the state of the request."
                     "#+begin_tool "
                     truncated-call
                     (propertize
-                     (concat "\n" call "\n\n" (org-escape-code-in-string result))
+                     (org-escape-code-in-string (concat "\n" call "\n\n" result))
                      'gptel `(tool . ,id))
                     "\n#+end_tool\n")
                  ;; TODO(tool) else branch is handling all front-ends as markdown.


### PR DESCRIPTION
Currently, tool results in org-mode `begin_tool ...` blocks are escaped using `org-escape-code-in-string` to prevent breaking out of the block structure.

However, the arguments list is not escaped, which can lead to structural breakage if, for example, an argument is a multi-line string.

Here's a simple repro (just run `gptel-send` in the buffer that gets created):

```emacs-lisp
;; -*- lexical-binding: t; -*-
;;
;; To test use `emacs -q --load [filename]`.
(require 'use-package)
(use-package
 gptel
 :custom
 (gptel-use-tools t)
 (gptel-include-tool-results t)
 :demand t
 ;; [...model/backend config...]
 )

(setq gptel-tools
      (list
       (gptel-make-tool
        :name "format_text"
        :function (lambda (text) text)
        :description "User-defined formatter"
        :args '((:name "text" :description "The text to format" :type string)))))

(let ((buf (generate-new-buffer "demo")))
  (with-current-buffer buf
    (org-mode)
    (gptel-mode)
    (insert "Call the \"format_text\" tool with exactly this text:\n\n* heading 1\n* heading 2"))
  (display-buffer buf))
```

Without the changes from this PR, the tool call will be formatted like:

```
Call the "format_text" tool with exactly this text:

* heading 1
* heading 2


#+begin_tool (format_text :text "* heading 1 * heading 2")
(:name "format_text" :args (:text "* heading 1
* heading 2"))

,* heading 1
,* heading 2
#+end_tool
```

Note the `* heading 2` in the arguments list causes the tool block to break.

With the changes from this PR, it looks like:

```
Call the "format_text" tool with exactly this text:

* heading 1
* heading 2


#+begin_tool (format_text :text "* heading 1 * heading 2")
(:name "format_text" :args (:text "* heading 1
,* heading 2"))

,* heading 1
,* heading 2
#+end_tool
```

The fix is basically to a) escape the entire tool block content rather than just the result, and b) remove the "read arguments" step in `gptel-org--unescape-tool-results`, so that the arguments also get properly unescaped when preparing requests. I'm not 100% sure whether there are additional edge cases that need to be considered here.