### PR TITLE
Add native Kimi backend with reasoning toggle

### DIFF
--- a/README.org
+++ b/README.org
@@ -93,7 +93,7 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
       - [[#aiml-api][AI/ML API]]
       - [[#github-copilotchat][GitHub CopilotChat]]
       - [[#aws-bedrock][AWS Bedrock]]
-      - [[#moonshot-kimi][Moonshot (Kimi)]]
+      - [[#moonshot-kimi][Kimi (Moonshot)]]
   - [[#usage][Usage]]
     - [[#in-any-buffer][In any buffer:]]
     - [[#in-a-dedicated-chat-buffer][In a dedicated chat buffer:]]
@@ -219,7 +219,7 @@ gptel supports a number of LLM providers:
 | xAI                  | [[https://console.x.ai?utm_source=github_gptel&utm_medium=github_readme&utm_campaign=link][API key]]                    |
 | GitHub CopilotChat   | GitHub account             |
 | Bedrock              | AWS credentials            |
-| Moonshot (Kimi)      | API key ([[https://platform.moonshot.cn/console][CN]] or [[https://platform.moonshot.ai/console][Global]])     |
+| Kimi (moonshot)      | API key ([[https://platform.moonshot.cn/console][CN]] or [[https://platform.moonshot.ai/console][Global]])     |
 #+html: </div>
 
 *** ChatGPT
@@ -1199,24 +1199,26 @@ The above code makes the backend available to select.  If you want it to be the 
 
 #+html: </details>
 #+html: <details><summary>
-**** Moonshot (Kimi)
+**** Kimi (Moonshot)
 #+html: </summary>
 
 Register a backend with
 
 #+begin_src emacs-lisp
-(gptel-make-openai "Moonshot"
-  :host "api.moonshot.cn" ;; or "api.moonshot.ai" for the global site
+(gptel-make-kimi "Kimi"
   :key "your-api-key"
-  :stream t ;; optionally enable streaming
-  :models '(kimi-latest kimi-k2-0711-preview))
+  :stream t)
 #+end_src
 
-See [[https://platform.moonshot.ai/docs/pricing/chat][Moonshot.ai document]] for a complete list of models.
+The default host is =api.moonshot.ai= (global).  Use =api.moonshot.cn= for the China region.
+
+Available models include =kimi-k2.5= (multimodal with thinking support), =kimi-k2-thinking= (reasoning model), and more.  See [[https://platform.moonshot.ai/docs/pricing/chat][Moonshot.ai document]] for details.
+
+For =kimi-k2.5=, thinking mode can be toggled via =gptel-include-reasoning=.
 
 ***** (Optional) Use the builtin search tool
 
-Moonshot supports a builtin search tool that does not requires the user to provide the tool implementation. To use that, you first need to define the tool and add to =gptel-tools= (while it does not requires the client to provide the search implementation, it does expects the client to reply a tool call message with its given argument, to be consistent with other tool calls):
+Kimi supports a builtin search tool that does not require the user to provide the tool implementation. To use that, you first need to define the tool and add to =gptel-tools= (while it does not require the client to provide the search implementation, it does expect the client to reply a tool call message with its given argument, to be consistent with other tool calls):
 
 #+begin_src emacs-lisp
 (setq gptel-tools
@@ -1225,7 +1227,7 @@ Moonshot supports a builtin search tool that does not requires the user to provi
              :function (lambda (&optional search_result)
                          (json-serialize
                           `(:search_result ,search_result)))
-             :description "Moonshot builtin web search. Only usable by moonshot model (kimi), ignore this if you are not."
+             :description "Kimi builtin web search. Only usable by kimi model, ignore this if you are not."
              :args '((:name "search_result" :type object :optional t))
              :category "web")))
 #+end_src
@@ -1233,11 +1235,9 @@ Moonshot supports a builtin search tool that does not requires the user to provi
 Then you also need to add the tool declaration via =:request-params= because it needs a special =builtin_function= type:
 
 #+begin_src emacs-lisp
-(gptel-make-openai "Moonshot"
-  :host "api.moonshot.cn" ;; or "api.moonshot.ai" for the global site
+(gptel-make-kimi "Kimi"
   :key "your-api-key"
-  :stream t ;; optionally enable streaming
-  :models '(kimi-latest kimi-k2-0711-preview)
+  :stream t
   :request-params '(:tools [(:type "builtin_function" :function (:name "$web_search"))]))
 #+end_src
 


### PR DESCRIPTION
The kimi API is mostly compatible with openai, but with the newest k2.5 model, a new reasoning switch and corresponding temperature setting is required.