### PR TITLE
gptel-transient: Fix display issues with evil visual selections

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -220,6 +220,9 @@
 * 0.9.9.4 2026-02-21
 
 ** Breaking changes
+- gptel now requires Transient 0.7.8 or higher. Transient is a built-in package
+  and Emacs does not update it by default.  Ensure that
+  =package-install-upgrade-built-in= is non-nil, or update Transient manually.
 
 - The models =gpt-5-codex=, =o3=, =o3-mini=, =o4-mini=,
   =claude-3.5-sonnet=, =claude-3.7-sonnet=, =claude-3.7-sonnet-thought=,

--- a/README.org
+++ b/README.org
@@ -135,7 +135,7 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
 
 ** Installation
 
-Note: gptel requires Transient 0.7.4 or higher.  Transient is a built-in package and Emacs does not update it by default.  Ensure that =package-install-upgrade-built-in= is true, or update Transient manually.
+Note: gptel requires Transient 0.7.8 or higher.  Transient is a built-in package and Emacs does not update it by default.  Ensure that =package-install-upgrade-built-in= is true, or update Transient manually.
 
 - *Release version*: =M-x package-install= ⏎ =gptel= in Emacs.
 - *Development snapshot*: Add MELPA or NonGNU-devel ELPA to your list of package sources, then install with =M-x package-install= ⏎ =gptel=.
@@ -151,7 +151,7 @@ Note: gptel requires Transient 0.7.4 or higher.  Transient is a built-in package
 #+html: <details><summary>
 *** Manual
 #+html: </summary>
-Note: gptel requires Transient 0.7.4 or higher.  Transient is a built-in package and Emacs does not update it by default.  Ensure that =package-install-upgrade-built-in= is true, or update Transient manually.
+Note: gptel requires Transient 0.7.8 or higher.  Transient is a built-in package and Emacs does not update it by default.  Ensure that =package-install-upgrade-built-in= is true, or update Transient manually.
 
 Clone or download this repository and run =M-x package-install-file⏎= on the repository directory.
 #+html: </details>

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -650,6 +650,7 @@ By default, gptel uses the directive associated with the `rewrite'
 ;;;###autoload (autoload 'gptel-rewrite "gptel-rewrite" nil t)
 (transient-define-prefix gptel-rewrite ()
   "Rewrite or refactor text region using an LLM."
+  :environment #'gptel--transient-fix-evil-visual
   [:description
    (lambda ()
      (gptel--describe-directive

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -542,6 +542,30 @@ which see."
             (propertize "@" 'face 'transient-key)
             (propertize "preset" 'face 'transient-inactive-value))))
 
+(defun gptel--transient-fix-evil-visual (fn)
+  "Let evil-mode set up the region correctly before displaying a transient.
+
+This is supposed to be used in the `:environment' slot of
+`transient-define-prefix'.
+
+The transient display code may be called from an entry in `post-command-hook',
+which may happen to run late, i.e., after evil-mode's entry in that hook has
+already teared down the temporary expanding of the region to a possibly existing
+visual selection.  This environment will ensure that the region is always
+expanded before calling the transient display code in FN.
+
+If evil-mode is not in use, this function is a no-op and calls FN directly."
+  (if (and (boundp 'evil-visual-region-expanded)
+           (not evil-visual-region-expanded)
+           (fboundp 'evil-visual-expand-region)
+           (fboundp 'evil-visual-contract-region))
+      (progn
+        (evil-visual-expand-region)
+        (funcall fn)
+        (when evil-visual-region-expanded
+          (evil-visual-contract-region)))
+    (funcall fn)))
+
 
 ;; * Transient classes and methods for gptel
 
@@ -775,6 +799,7 @@ Also format the value of OBJ in the transient menu."
 (transient-define-prefix gptel-menu ()
   "Change parameters of prompt to send to the LLM."
   :incompatible '(("m" "y" "i") ("e" "g" "b" "k"))
+  :environment #'gptel--transient-fix-evil-visual
   ;; :value (list (concat "b" (buffer-name)))
   [:description gptel-system-prompt--format
    [""

--- a/gptel.el
+++ b/gptel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Karthik Chikmagalur <karthik.chikmagalur@gmail.com>
 ;; Version: 0.9.9.5
-;; Package-Requires: ((emacs "27.1") (transient "0.7.4") (compat "30.1.0.0"))
+;; Package-Requires: ((emacs "27.1") (transient "0.7.8") (compat "30.1.0.0"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/karthink/gptel
 


### PR DESCRIPTION
Fixes #909 and a few other issues, e.g., missing "Rewrite r" choices in the transient menu when there's an evil visual selection.

I played around with multiple approaches, but I think this is by far the cleanest fix. First, it kills the problem entirely, i.e., we won't need to change every `(use-region-p)`, `(region-beginning)`, etc. responsible for displaying a transient, which would be very annoying to maintain. Second, this approach is not very hacky because it uses a mechanism offered by transient for setting up an "environment" in which the display code runs.

We'll need transient 0.7.8. I think it's fine to bump it -- the release dates differ just by a few months -- but we can also make the code conditional in the version if you prefer that approach. 

I couldn't notice any difference in performance, and performance should anyway be totally fine: 
 - The first thing `evil-visual-expand-region` does is to check if there's a visual selection, i.e., if there's anything to do at all. If not, it returns immediately. (Note that these evil functions are performance-critical in evil-mode itself because they run in the pre/post-command-hook.)
 - The code is skipped if the region is already expanded.
 - The code is skipped entirely if evil-mode is not loaded.