### PR TITLE
inherit stickiness results in overwriting ignore regions when restoring a session with tool output saved.

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -600,7 +600,8 @@ the gptel property is set to just PROP.
 
 The legacy structure, a list of (BEG . END) is also supported and will be
 applied before being re-persisted in the new structure."
-  (let ((modified (buffer-modified-p)))
+  (let ((modified (buffer-modified-p))
+        (inhibit-modification-hooks t))
     (if (symbolp (caar bounds-alist))
         (mapc
          (lambda (bounds)


### PR DESCRIPTION
This certainly seems like a bug to me.  The analysis is almost entirely done by Claude, but I have reviewed it and tested.  I'm interested to learn if there are other, better, ways to approach this fix.

During restoration, gptel--inherit-stickiness was copying adjacent properties and overwriting intentional property assignments, causing tool call regions to be incorrectly marked and failing to serialize.

This manifested as tool calls showing "name": {} and "input": {} in API requests because the ignore property regions were being overwritten with adjacent tool properties.

[example session](https://gist.github.com/moogah/34211d3f341b785088e8b765521ef334)
When loading this file, the following operations would occur:
`add-text-properties(37 80 (gptel ignore))` - correct call
`gptel--inherit-stickiness(37 80 43)` - after-change-functions triggered
`add-text-properties(37 80 (gptel (tool ...)))` - overwrites ignore!
