### PR TITLE
README: Expand Doom Emacs section

### DIFF
--- a/README.org
+++ b/README.org
@@ -174,6 +174,14 @@ In =config.el=
 
 "your key" can be the API key itself, or (safer) a function that returns the key.  Setting =gptel-api-key= is optional, you will be asked for a key if it's not found.
 
+Alternatively, Doom Emacs provides a built-in =:tools llm= [[https://github.com/doomemacs/doomemacs/tree/master/modules/tools/llm][module]] powered by gptel.  Enable it in your =init.el= in the =doom!= block:
+
+#+begin_src emacs-lisp
+(doom! :tools llm)
+#+end_src
+
+This installs gptel with preconfigured keybindings (=<leader> o l=), magit integration for generating commit messages (=M-g= in commit buffers), and packages =gptel-quick= and =gptel-magit=.  Run =doom/help-modules= (=<leader> h d m=) and select =:tools llm= for full documentation.
+
 #+html: </details>
 #+html: <details><summary>
 *** Spacemacs


### PR DESCRIPTION
Add info about native Doom Emacs module, which use gptel as main driver.

If this is too much, and basic instalation is enough, don't bother and just reject PR. 