### PR TITLE
feat: add customizable AWS CLI command path

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,6 +56,9 @@
   results, block the tool call but continue the request, or stop the
   request entirely.
 
+- New variable ~gptel-bedrock-aws-cli-command~ to set the path to the
+  AWS CLI command for the Bedrock backend.  Defaults to "ews".
+
 ** Notable bug fixes
 
 - ~gptel-backend~ can now be set from customize buffers.  These are

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -516,6 +516,12 @@ conversation."
 (defvar gptel-bedrock--aws-profile-cache nil
   "Cache for AWS profile credentials in the form of (PROFILE . CREDS).")
 
+(defvar gptel-bedrock-aws-cli-command (executable-find "aws")
+  "Path to the AWS CLI command.
+
+Can be customized to use a specific AWS CLI installation,
+e.g. \"/usr/local/bin/aws\".")
+
 (defun gptel-bedrock--fetch-aws-profile-credentials (profile &optional clear-cache)
   "Fetch & cache AWS credentials for PROFILE using aws-cli.
 
@@ -529,7 +535,8 @@ Non-nil CLEAR-CACHE will refresh credentials."
              (or (and (not clear-cache) (cdr cell))
                  (setf (cdr cell)
                        (with-temp-buffer
-		           (unless (zerop (apply #'call-process "aws" nil t nil "configure" "export-credentials"
+		           (unless (zerop (apply #'call-process gptel-bedrock-aws-cli-command
+                                                 nil t nil "configure" "export-credentials"
                                                  (unless (eql profile :static) (list (format "--profile=%s" profile)))))
 		             (user-error "Failed to get AWS credentials from profile"))
 		         (json-parse-string (buffer-string)))))))


### PR DESCRIPTION
### Motivation
Users may need to:
- Use a specific AWS CLI installation (e.g., `/usr/local/bin/aws`, `/opt/homebrew/bin/aws`)
- Handle environments where the AWS CLI is not in the default `$PATH`
- Manage multiple AWS CLI versions for different projects

### Usage Guide

#### Default behavior (no configuration needed)
By default, gptel will continue to use the `aws` command from your `$PATH`:
```elisp
;; No configuration needed - uses "aws" from PATH
```

#### Custom AWS CLI path
To specify a custom AWS CLI installation path:
```elisp
(setq gptel-bedrock-aws-cli-command "/usr/local/bin/aws")
```