### PR TITLE
Fix header-line right-alignment for variable-pitch fonts

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -828,19 +828,22 @@ Search between BEG and END."
                                 toggle-tools)
                      'mouse-face 'highlight
                      'help-echo "Select tools"))))
-      (concat
-       (propertize
-        " " 'display
-        `(space :align-to (- right
-                             ,(+ 5 (length model) (length system)
-                                 (length track-media) (length context) (length tools)))))
-       tools (and track-media " ") track-media (and context " ") context " " system " "
-       (propertize
-        (buttonize (concat "[" model "]")
-                   (lambda (&rest _) (gptel-menu)))
-        'mouse-face 'highlight
-        'help-echo "Model in use"))))
-  "Information segment for the header-line in gptel-mode.")
+      (let ((rhs (concat
+                  tools (and track-media " ") track-media
+                  (and context " ") context " " system " "
+                  (propertize
+                   (buttonize (concat "[" model "]")
+                              (lambda (&rest _) (gptel-menu)))
+                   'mouse-face 'highlight
+                   'help-echo "Model in use"))))
+        (concat
+         (propertize
+          " " 'display
+          (if (fboundp 'string-pixel-width)
+              `(space :align-to (- right (,(string-pixel-width rhs))))
+            `(space :align-to (- right ,(+ 5 (string-width rhs))))))
+         rhs))))
+  "Information segment for the header-line in `gptel-mode'.")
 
 (defun gptel-use-header-line ()
   "Set up the header-line for a gptel buffer.


### PR DESCRIPTION
Fixes #763 — header-line right-alignment off due to `length` counting characters instead of pixel width.

Builds the RHS string first, then uses `string-pixel-width` (Emacs 29+, falls back to `string-width`) for font-independent alignment. Eliminates hardcoded offset.

**Verified** on Emacs 30.2: old spec used `(- right 43)` (char-based + hardcoded 5), new spec uses `(- right (38))` (pixel-wrapped form).