### PR TITLE
xAI: `grok-4{,-1}-fast-{,-non}-reasoning`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,11 @@
   ChatGPT backend is created on the fly and used.
 
 ** New models and backends
+
+- xAI backend: Add support for =grok-4-1-fast-reasoning=,
+  =grok-4-1-fast-non-reasoning=, =grok-4-fast-reasoning=, and
+  =grok-4-fast-non-reasoning=.
+
 ** New features and UI changes
 
 - When using ~setopt~ or the customize interface, ~gptel-backend~ can
@@ -459,7 +464,7 @@
   ~gptel-mcp-disconnect~.  You can use these to start MCP servers
   selectively and add tools to gptel.  These commands are also
   available from gptel's tools menu.
-  
+
   These commands are currently not autoloaded by gptel.  To access
   them, require the ~gptel-integrations~ feature.
 
@@ -501,7 +506,7 @@
   path.
 
 - The current kill can be added to gptel's context.  To enable this,
-  turn on ~gptel-expert-commands~ and use gptel's transient menu. 
+  turn on ~gptel-expert-commands~ and use gptel's transient menu.
 
 - The tools menu (~gptel-tools~) has been redesigned.  It now displays
   tool categories and associated tools in two columns, and it should

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -345,12 +345,19 @@ For the meanings of the keyword arguments, see `gptel-make-openai'."
           (protocol "https")
           (endpoint "/v1/chat/completions")
           (models
-           '((grok-4
-              :description "Grok Flagship model"
+           '((grok-4-1-fast-reasoning
+              :description "Fast tool-calling model"
               :capabilities (tool-use json reasoning)
               :context-window 256
-              :input-cost 3
-              :output-cost 15)
+              :input-cost 0.2
+              :output-cost 0.5)
+
+             (grok-4-1-fast-non-reasoning
+              :description "Fast tool-calling model (non-reasoning)"
+              :capabilities (tool-use json)
+              :context-window 256
+              :input-cost 0.2
+              :output-cost 0.5)
 
              (grok-code-fast-1
               :description "Fast reasoning model for agentic coding"
@@ -359,19 +366,26 @@ For the meanings of the keyword arguments, see `gptel-make-openai'."
               :input-cost 0.2
               :output-cost 1.5)
 
-             (grok-3
-              :description "Grok 3"
+             (grok-4-fast-reasoning
+              :description "Fast tool-calling model"
               :capabilities (tool-use json reasoning)
-              :context-window 131
+              :context-window 256
+              :input-cost 0.2
+              :output-cost 0.5)
+
+             (grok-4-fast-non-reasoning
+              :description "Fast tool-calling model (non-reasoning)"
+              :capabilities (tool-use json)
+              :context-window 256
+              :input-cost 0.2
+              :output-cost 0.5)
+
+             (grok-4
+              :description "Grok Flagship model"
+              :capabilities (tool-use json reasoning)
+              :context-window 256
               :input-cost 3
               :output-cost 15)
-
-             (grok-3-fast
-              :description "Faster Grok 3"
-              :capabilities (tool-use json reasoning)
-              :context-window 131
-              :input-cost 5
-              :output-cost 25)
 
              (grok-3-mini
               :description "Mini Grok 3"
@@ -380,12 +394,12 @@ For the meanings of the keyword arguments, see `gptel-make-openai'."
               :input-cost 0.3
               :output-cost 0.5)
 
-             (grok-3-mini-fast
-              :description "Faster mini Grok 3"
+             (grok-3
+              :description "Grok 3"
               :capabilities (tool-use json reasoning)
-              :context-window 131072
-              :input-cost 0.6
-              :output-cost 4)
+              :context-window 131
+              :input-cost 3
+              :output-cost 15)
 
              (grok-2-vision-1212
               :description "Grok 2 Vision"


### PR DESCRIPTION
Add support for some missing Grok models, and re-sort the backend config to match the list at https://docs.x.ai/developers/models for easy future syncing.