### PR TITLE
gptel-gh: Update models list

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,9 @@
   =grok-4-1-fast-non-reasoning=, =grok-4-fast-reasoning=, and
   =grok-4-fast-non-reasoning=.
 
+- - GitHub Copilot backend: Add support for =gpt-5.1-codex-,
+  =gpt-5.1-codex-mini, =claude-sonnet-4.6= and =gemini-3.1-pro-preview=.
+
 ** New features and UI changes
 
 - When using ~setopt~ or the customize interface, ~gptel-backend~ can

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -28,41 +28,60 @@
 
 ;;; Github Copilot
 (defconst gptel--gh-models
-  '((gpt-4o
+  '((gpt-4.1
+     :description "Flagship model for complex tasks"
+     :capabilities (media tool-use json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 111
+     :input-cost 0
+     :output-cost 0
+     :cutoff-date "2024-04")
+    (gpt-4o
      :description
      "Advanced model for complex tasks; cheaper & faster than GPT-Turbo"
      :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128 :input-cost 0 :output-cost 0 :cutoff-date "2023-10")
-    (gpt-4.1
-     :description "Flagship model for complex tasks"
+     :context-window 64
+     :input-cost 0
+     :output-cost 0
+     :cutoff-date "2023-09")
+    (gpt-5-mini
+     :description "Faster, more cost-efficient version of GPT-5"
      :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
      :context-window 128
      :input-cost 0
      :output-cost 0
-     :cutoff-date "2024-05")
-    (gpt-5.1-codex-max
-     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
-     :capabilities (media tool-use json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 400
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2024-09")
-    (gpt-5-mini
-     :description "Faster, more cost-efficient version of GPT-5"
-     :capabilities (media tool-use json url)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 264
-     :input-cost 0
-     :output-cost 0
-     :cutoff-date "2024-09")
+     :cutoff-date "2024-06")
     (gpt-5.1
      :description "The best model for coding and agentic tasks"
      :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 400
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2024-09")
+    (gpt-5.1-codex
+     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
+     :capabilities (media tool-use json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2024-09")
+    (gpt-5.1-codex-max
+     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
+     :capabilities (media tool-use json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2024-09")
+    (gpt-5.1-codex-mini
+     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
+     :capabilities (media tool-use json url)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 128
      :input-cost 1
      :output-cost 1
      :cutoff-date "2024-09")
@@ -70,7 +89,7 @@
      :description "The best model for coding and agentic tasks"
      :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 400
+     :context-window 128
      :input-cost 1
      :output-cost 1
      :cutoff-date "2025-08")
@@ -78,31 +97,15 @@
      :description "The best model for coding and agentic tasks"
      :capabilities (media tool-use json url)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 400
+     :context-window 272
      :input-cost 1
      :output-cost 1
      :cutoff-date "2025-08")
-    (claude-sonnet-4
-     :description "High-performance model with exceptional reasoning and efficiency"
-     :capabilities (media tool-use cache)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 216
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-03")
-    (claude-sonnet-4.5
-     :description "High-performance model with exceptional reasoning and efficiency"
-     :capabilities (media tool-use cache)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 144
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-07")
     (claude-haiku-4.5
      :description "Near-frontier intelligence at blazing speeds with extended thinking"
      :capabilities (media tool-use cache)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 144
+     :context-window 128
      :input-cost 0.33
      :output-cost 0.33
      :cutoff-date "2025-02")
@@ -110,27 +113,51 @@
      :description "Most capable model for complex reasoning and advanced coding"
      :capabilities (media tool-use cache)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 144
+     :context-window 128
      :input-cost 3
      :output-cost 3
-     :cutoff-date "2025-05")
+     :cutoff-date "2025-03")
     (claude-opus-4.6
      :description "Most capable model for complex reasoning and advanced coding"
      :capabilities (media tool-use cache)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 200
+     :context-window 128
      :input-cost 3
      :output-cost 3
-     :cutoff-date "2025-08")
+     :cutoff-date "2025-03")
+    (claude-sonnet-4
+     :description "High-performance model with exceptional reasoning and efficiency"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2025-03")
+    (claude-sonnet-4.5
+     :description "High-performance model with exceptional reasoning and efficiency"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2025-03")
+    (claude-sonnet-4.6
+     :description "High-performance model with exceptional reasoning and efficiency"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 128
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2025-03")
     (gemini-2.5-pro
      :description "Next gen, high speed, multimodal for a diverse variety of tasks"
      :capabilities (tool-use json media)
      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
                   "application/pdf" "text/plain" "text/csv" "text/html")
-     :context-window 128
+     :context-window 109
      :input-cost 1
      :output-cost 1
-     :cutoff-date "2024-08")
+     :cutoff-date "2025-01")
     (gemini-3-flash-preview
      :description "Most intelligent Gemini model built for speed"
      :capabilities (tool-use json media audio video)
@@ -138,7 +165,7 @@
                   "application/pdf" "text/plain" "text/csv" "text/html"
                   "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
                   "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
-     :context-window 128
+     :context-window 109
      :input-cost 0.33
      :output-cost 0.33
      :cutoff-date "2025-01")
@@ -149,16 +176,28 @@
                   "application/pdf" "text/plain" "text/csv" "text/html"
                   "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
                   "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
-     :context-window 128
+     :context-window 109
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2025-01")
+    (gemini-3.1-pro-preview
+     :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 109
      :input-cost 1
      :output-cost 1
      :cutoff-date "2025-01")
     (grok-code-fast-1
      :description "Fast reasoning model for agentic coding"
      :capabilities '(tool-use json reasoning)
-     :context-window 128
-     :input-cost 0.2
-     :output-cost 1.5)))
+     :context-window 109
+     :input-cost 0.25
+     :output-cost 1.5
+     :cutoff-date "2025-08")))
 
 (cl-defstruct (gptel--gh (:include gptel-openai)
                          (:copier nil)


### PR DESCRIPTION
Cleaned up old models and added missing ones:
- `gpt-41-copilot` is a code completion model and cannot be used by `gptel`
- both `gpt-5` and `claude-opus-41` are no longer supported

However, some exisiting, as well as newly added, OpenAi models (starting from `gpt-5.1-codex`) are not supported by `/chat/completions` endpoint so at this point it may be pointless to have them.