### PR TITLE
#1294, fix: Deprecated model ‘llama3-70b-8192’ removed

### DIFF
--- a/README.org
+++ b/README.org
@@ -748,7 +748,6 @@ The above code makes the backend available to select.  If you want it to be the 
         :key "your-api-key"
         :models '(llama-3.1-70b-versatile
                   llama-3.1-8b-instant
-                  llama3-70b-8192
                   llama3-8b-8192
                   mixtral-8x7b-32768
                   gemma-7b-it)))


### PR DESCRIPTION
Removes deprecated model ‘llama3-70b-8192’ - alternative model already in README.