### PR TITLE
Fix: Handle nil/null tool names during streaming

### DIFF
--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -139,22 +139,28 @@ information if the stream contains it."
                   ;; No text content, so look for tool calls
                   (when-let* ((tool-call (map-nested-elt delta '(:tool_calls 0)))
                               (func (plist-get tool-call :function)))
-                    (if (and-let* ((func-name (plist-get func :name)) ((not (eq func-name :null))))
-                          ;; TEMP: This check is for litellm compatibility, should be removed
-                          (not (equal func-name "null"))) ; new tool block begins
-                        (progn
-                          (when-let* ((partial (plist-get info :partial_json)))
-                            (let* ((prev-tool-call (car (plist-get info :tool-use)))
-                                   (prev-func (plist-get prev-tool-call :function)))
-                              (plist-put prev-func :arguments ;update args for old tool block
-                                         (apply #'concat (nreverse (plist-get info :partial_json)))))
-                            (plist-put info :partial_json nil)) ;clear out finished chain of partial args
-                          ;; Start new chain of partial argument strings
-                          (plist-put info :partial_json (list (plist-get func :arguments)))
-                          ;; NOTE: Do NOT use `push' for this, it prepends and we lose the reference
-                          (plist-put info :tool-use (cons tool-call (plist-get info :tool-use))))
-                      ;; old tool block continues, so continue collecting arguments in :partial_json 
-                      (push (plist-get func :arguments) (plist-get info :partial_json)))))
+                    (let ((func-name (plist-get func :name)))
+                      (cond
+                       ;; New tool block with valid name
+                       ((and func-name
+                             (not (eq func-name :null))
+                             ;; TEMP: litellm compatibility
+                             (not (equal func-name "null")))
+                        (when-let* ((partial (plist-get info :partial_json)))
+                          (let* ((prev-tool-call (car (plist-get info :tool-use)))
+                                 (prev-func (plist-get prev-tool-call :function)))
+                            (plist-put prev-func :arguments
+                                       (apply #'concat (nreverse (plist-get info :partial_json))))))
+                        (plist-put info :partial_json nil)
+                        (plist-put info :partial_json (list (plist-get func :arguments)))
+                        (plist-put info :tool-use (cons tool-call (plist-get info :tool-use))))
+                       ;; Malformed tool call: nil/null name at start of new block
+                       ((and (or (null func-name) (eq func-name :null) (equal func-name "null"))
+                             (not (plist-get info :partial_json)))
+                        (message "gptel-openai: skipping tool call with nil/null name"))
+                       ;; Old tool block continues
+                       ((plist-get info :partial_json)
+                        (push (plist-get func :arguments) (plist-get info :partial_json)))))))
                 ;; Check for reasoning blocks, currently only used by Openrouter
                 (unless (eq (plist-get info :reasoning-block) 'done)
                   (if-let* ((reasoning-plist ;reasoning-plist is (:reasoning.* "chunk" ...) or nil

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -146,7 +146,7 @@ information if the stream contains it."
                              (not (eq func-name :null))
                              ;; TEMP: litellm compatibility
                              (not (equal func-name "null")))
-                        (when-let* ((partial (plist-get info :partial_json)))
+                        (when (plist-get info :partial_json)
                           (let* ((prev-tool-call (car (plist-get info :tool-use)))
                                  (prev-func (plist-get prev-tool-call :function)))
                             (plist-put prev-func :arguments
@@ -157,7 +157,7 @@ information if the stream contains it."
                        ;; Malformed tool call: nil/null name at start of new block
                        ((and (or (null func-name) (eq func-name :null) (equal func-name "null"))
                              (not (plist-get info :partial_json)))
-                        (message "gptel-openai: skipping tool call with nil/null name"))
+                        (display-warning 'gptel-openai "Skipping tool call with nil/null name"))
                        ;; Old tool block continues
                        ((plist-get info :partial_json)
                         (push (plist-get func :arguments) (plist-get info :partial_json)))))))


### PR DESCRIPTION
## Problem

When an LLM returns a tool call with `nil`, `:null`, or `"null"` as the function name during streaming, the current code incorrectly treats it as "old tool block continues" and pushes arguments to `:partial_json`. This creates malformed tool entries that can hang the FSM indefinitely.

## Root Cause

The `if` statement in `gptel-openai--stream-parse-tool-call` has two branches:
1. Valid function name → new tool block
2. Everything else → "old tool block continues"

But when the function name is nil/null at the **start** of a new tool block (no previous `:partial_json`), falling through to "old tool block continues" is incorrect and creates corrupted state.

## Solution

Use `cond` to explicitly handle three cases:
1. **Valid function name** → new tool block (unchanged behavior)
2. **Invalid function name at start of new block** → log warning, skip the malformed call
3. **Continuing previous tool block** → collect arguments (unchanged behavior)

## Testing

This issue was observed with DashScope (Alibaba Qwen) models returning malformed tool calls. The fix has been tested locally with:
- Normal tool calls continue to work
- Malformed tool calls are logged and skipped
- FSM no longer hangs

## Changes

- `gptel-openai.el`: Replace `if` with `cond` in streaming tool call parser to explicitly handle nil/null function names