### PR TITLE
Update project homepage

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -6,7 +6,7 @@
 ;; Version: 0.9.9.4
 ;; Package-Requires: ((emacs "27.1") (transient "0.7.4") (compat "30.1.0.0"))
 ;; Keywords: convenience, tools
-;; URL: https://github.com/karthink/gptel
+;; URL: https://gptel.org
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
The project has a rather attractive homepage at gptel.org, which I believe serves as a more appealing landing page for end users compared to GitHub. This is presented in Emacs when using `describe-package`. Additionally, the GNU project, FSF, and RMS disapprove of GitHub due to concerns about computing freedom, so this is better for non-gnu ELPA listing.