### PR TITLE
Fix crash in gptel-mcp--activate-tools when requested servers return no tools

### DIFF
--- a/gptel-integrations.el
+++ b/gptel-integrations.el
@@ -160,10 +160,10 @@ not a function and non-nil, start SERVERS synchronously."
                   (lambda (&optional server-names)
                     "Register and add tools from servers.  Report failures."
                     (let ((tools (gptel-mcp--get-tools
-                                  (or server-names (mapcar #'car inactive-servers))))
+                                  (or server-names (mapcar #'car servers))))
                           (now-active (cl-remove-if-not server-active-p mcp-hub-servers)))
                       (mapc (lambda (tool) (apply #'gptel-make-tool tool)) tools)
-                      (gptel-mcp--activate-tools tools)
+                      (when tools (gptel-mcp--activate-tools tools))
                       (if-let* ((failed (cl-set-difference inactive-servers now-active
                                                            :test #'equal)))
                           (progn


### PR DESCRIPTION
## Problem

`gptel-mcp-connect` has two bugs in its `add-all-tools` callback that surface when calling it programmatically for specific servers:

### Bug 1: Crash on nil tools list

When the requested servers fail to start or return no tools, the callback passes nil to `gptel-mcp--activate-tools`. Its `(unless tools ...)` fallback fetches tools from **all** connected MCP servers and tries to look them up via `gptel-get-tool`, crashing on tools from servers that were never registered with `gptel-make-tool`:

```
No tool matches for ("mcp-home-assistant" "HassTurnOn")
```

even though home-assistant was never requested.

### Bug 2: Active-but-unregistered servers skipped

When there is a mix of active-but-unregistered and inactive-but-unregistered servers, the callback's fallback `(mapcar #'car inactive-servers)` only processes the inactive ones. Tools from already-active servers that still need registration are silently dropped.

For example, if brave-search (active, connected) and slack (inactive, init) are both unregistered:
1. `mcp-hub-start-all-server` starts only slack
2. The callback falls back to `inactive-servers` → only slack
3. brave-search tools are never registered despite being available

## Fix

Two one-line changes in the `add-all-tools` lambda:

1. Guard `gptel-mcp--activate-tools` with `when` so nil means "nothing to activate" rather than "activate everything".
2. Change the fallback from `inactive-servers` to `servers` (all unregistered), so the callback registers tools from every server that needs it—both those just started and those already active.