### PR TITLE
Fix nil token fields in `message_delta` crashing streaming tool calls

### DIFF
--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -45,13 +45,13 @@
 USAGE is part of the response, INFO is the request plist."
   (when usage
     (let* ((tokens (plist-get info :tokens))
-           (input (+ (plist-get usage :input_tokens)
+           (input (+ (or (plist-get usage :input_tokens) 0)
                      (or (plist-get tokens :input) 0)))
-           (output (+ (plist-get usage :output_tokens)
+           (output (+ (or (plist-get usage :output_tokens) 0)
                       (or (plist-get tokens :output) 0)))
-           (cached (+ (plist-get usage :cache_read_input_tokens)
+           (cached (+ (or (plist-get usage :cache_read_input_tokens) 0)
                       (or (plist-get tokens :cached) 0)))
-           (cache (+ (plist-get usage :cache_creation_input_tokens)
+           (cache (+ (or (plist-get usage :cache_creation_input_tokens) 0)
                      (or (plist-get tokens :cache) 0))))
       (list :input input :output output
             :cache cache :cached cached))))


### PR DESCRIPTION
**Problem**

cc @karthink i've been having a trouble with tool calling in gptel-agent:

Streaming tool calls crash with `Wrong type argument: number-or-marker-p, nil` in the process sentinel, which then manifests as `Wrong type argument: char-or-string-p, nil` in `gptel--display-tool-calls`.

The Anthropic API's `message_delta` SSE event only includes `output_tokens` in its `usage` field — not `input_tokens`, `cache_read_input_tokens`, or `cache_creation_input_tokens` (those are only in `message_start`). `gptel--anthropic-update-tokens` passes these nil values to `+`, which signals an error.

Because this function is called from inside the `message_delta` handler of the streaming parser, the error prevents the handler from copying `:input` to `:args` on each tool-call plist. The outer `condition-case` catches the error and rewinds the parser, but on retry `:input` has already been nilled out by partial execution. The sentinel then transitions the FSM with tool-calls that have nil args, and downstream preview handlers crash on `(insert nil)`.

**Fix**

Wrap all `plist-get` calls for usage fields with `(or ... 0)`, matching the existing defensive pattern already used for the accumulator (`tokens`) fields on the same lines.

**Introduced by**

Commit a4cc9a1 ("gptel-anthropic: Add plumbing for token usage tracking")