### PR TITLE
gptel: allow anonymous plist parents in gptel--apply-preset

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2572,73 +2572,73 @@ two arguments, the symbol being set and the value to set it to.  It
 defaults to `set', and can be set to a different function to (for
 example) apply the preset buffer-locally."
   (unless setter (setq setter #'set))
-  (cl-flet ((get-preset (preset)
-              (or (gptel-get-preset preset)
-                  (user-error "gptel preset \"%s\": Cannot find preset"
-                              preset))))
+  (let* ((spec (if (memq (type-of preset) '(string symbol))
+                   (or (gptel-get-preset preset)
+                       (user-error "gptel preset \"%s\": Cannot find preset"
+                                   preset))
+                 preset)))
+    (when-let* ((func (plist-get spec :pre))) (funcall func))
+    (when-let* ((parents (plist-get spec :parents)))
+      (mapc (lambda (parent) (gptel--apply-preset parent setter))
+            (ensure-list parents)))
+    ;; Record preset name for persistence and UI display
     (when (memq (type-of preset) '(string symbol))
-      (let ((spec (get-preset preset)))
-        (funcall setter 'gptel--preset preset)
-        (setq preset spec)))
-    (when-let* ((func (plist-get preset :pre))) (funcall func))
-    (when-let* ((parents (plist-get preset :parents)))
-      (mapc (lambda (parent) (gptel--apply-preset (get-preset parent) setter))
-            (ensure-list parents))))
-  (map-do
-   (lambda (key val)
-     (pcase key
-       ((or :parents :description :pre :post) nil)
-       ((or :system :system-message :rewrite-directive)
-        (let ((sym (if (eq key :rewrite-directive)
-                       'gptel--rewrite-directive 'gptel--system-message)))
-          (when (consp val)
-            ;; Possibly complain about trying to compose a system message string
-            ;; with a non-string
-            ;; TODO(modify-list): Catch other incompatible combinations
-            (and (or (plist-member val :append) (plist-member val :prepend))
-                 (not (stringp (symbol-value sym)))
-                 (user-error "Composing non-string system messages is not implemented"))
-            (setq val (gptel--modify-value (symbol-value sym) val)))
-          (if (and (symbolp val) (not (functionp val)))
-              (if-let* ((directive (alist-get val gptel-directives)))
-                  (funcall setter sym directive)
-                (user-error "gptel preset: Cannot find directive %s" val))
-            (funcall setter sym val))))
-       (:backend
-        (when (consp val) (setq val (gptel--modify-value 'gptel-backend val)))
-        (setq val (cl-etypecase val
-                    (gptel-backend val)
-                    (string (gptel-get-backend val))))
-        (unless val
-          (user-error "gptel preset: Cannot find backend %s" val))
-        (funcall setter 'gptel-backend val))
-       (:tools                          ;TEMP Confirm this `:append' convention
-        (setq val (gptel--modify-value gptel-tools val))
-        (let* ((tools
-                (flatten-list
-                 (cl-loop for tool-name in (ensure-list val)
-                          for tool = (cl-etypecase tool-name
-                                       (gptel-tool tool-name)
-                                       (string (ignore-errors
-                                                 (gptel-get-tool tool-name))))
-                          do (unless tool
-                               (user-error "gptel preset: Cannot find tool %S"
-                                           tool-name))
-                          collect tool))))
-          (funcall setter 'gptel-tools (cl-delete-duplicates tools :test #'eq))))
-       ((and (let sym (or (intern-soft
-                           (concat "gptel-" (substring (symbol-name key) 1)))
-                          (intern-soft
-                           (concat "gptel--" (substring (symbol-name key) 1)))))
-             (guard (and sym (boundp sym))))
-        (funcall setter sym (if (consp val)
-                                (gptel--modify-value (symbol-value sym) val)
-                              val)))
-       (_ (display-warning
-           '(gptel presets)
-           (format "gptel preset: setting for %s not found, ignoring." key)))))
-   preset)
-  (when-let* ((func (plist-get preset :post))) (funcall func)))
+      (funcall setter 'gptel--preset preset))
+    (map-do
+     (lambda (key val)
+       (pcase key
+         ((or :parents :description :pre :post) nil)
+         ((or :system :system-message :rewrite-directive)
+          (let ((sym (if (eq key :rewrite-directive)
+                         'gptel--rewrite-directive 'gptel--system-message)))
+            (when (consp val)
+              ;; Possibly complain about trying to compose a system message string
+              ;; with a non-string
+              ;; TODO(modify-list): Catch other incompatible combinations
+              (and (or (plist-member val :append) (plist-member val :prepend))
+                   (not (stringp (symbol-value sym)))
+                   (user-error "Composing non-string system messages is not implemented"))
+              (setq val (gptel--modify-value (symbol-value sym) val)))
+            (if (and (symbolp val) (not (functionp val)))
+                (if-let* ((directive (alist-get val gptel-directives)))
+                    (funcall setter sym directive)
+                  (user-error "gptel preset: Cannot find directive %s" val))
+              (funcall setter sym val))))
+         (:backend
+          (when (consp val) (setq val (gptel--modify-value 'gptel-backend val)))
+          (setq val (cl-etypecase val
+                      (gptel-backend val)
+                      (string (gptel-get-backend val))))
+          (unless val
+            (user-error "gptel preset: Cannot find backend %s" val))
+          (funcall setter 'gptel-backend val))
+         (:tools                          ;TEMP Confirm this `:append' convention
+          (setq val (gptel--modify-value gptel-tools val))
+          (let* ((tools
+                  (flatten-list
+                   (cl-loop for tool-name in (ensure-list val)
+                            for tool = (cl-etypecase tool-name
+                                         (gptel-tool tool-name)
+                                         (string (ignore-errors
+                                                   (gptel-get-tool tool-name))))
+                            do (unless tool
+                                 (user-error "gptel preset: Cannot find tool %S"
+                                             tool-name))
+                            collect tool))))
+            (funcall setter 'gptel-tools (cl-delete-duplicates tools :test #'eq))))
+         ((and (let sym (or (intern-soft
+                             (concat "gptel-" (substring (symbol-name key) 1)))
+                            (intern-soft
+                             (concat "gptel--" (substring (symbol-name key) 1)))))
+               (guard (and sym (boundp sym))))
+          (funcall setter sym (if (consp val)
+                                  (gptel--modify-value (symbol-value sym) val)
+                                val)))
+         (_ (display-warning
+             '(gptel presets)
+             (format "gptel preset: setting for %s not found, ignoring." key)))))
+     spec)
+    (when-let* ((func (plist-get spec :post))) (funcall func))))
 
 (defun gptel--preset-syms (preset)
   "Return a list of gptel variables (symbols) set by PRESET.


### PR DESCRIPTION
`gptel--apply-preset` previously always tried to resolve parents using `gptel-get-preset` (via the `cl-flet`'ed `get-preset`), which throws a `user-error` for anonymous (i.e. plist) parent presets.

This appears to have been introduced in https://github.com/karthink/gptel/commit/c3d5d7f758b8fbb071abbd18d599d1eacb0f2fbd.

The `get-preset` wrapper is still needed for parent resolution (to avoid overwriting `gptel--preset` with a parent symbol), so this fix adds a type check rather than removing the call.

Here's a simple repro:

```emacs-lisp
;; -*- lexical-binding: t; -\_-
;;
;; To test use `emacs -q --load [filename]`.
(require 'use-package)
(use-package
  gptel
  :demand t
  ;; Or wherever.
  :load-path "elpaca/sources/gptel")

(let\* ((base '(:system "base "))
        (main (list :parents (list base) :system '(:append "main"))))
       ;; Without fix: (user-error "gptel preset \"(:system base )\": Cannot find preset")
       ;; With fix: "base main"
       (gptel--apply-preset main)
       (message "gptel--system-message: %S" gptel--system-message))
```
