### PR TITLE
Fix streaming responses

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -724,11 +724,16 @@ See `gptel-backend'."
   :type '(repeat string))
 
 (defconst gptel-curl--common-args
-  (if (memq system-type '(windows-nt ms-dos))
-      '("--disable" "--location" "--silent" "-XPOST"
-        "-y7200" "-Y1" "-D-")
+  (cond
+   ((memq system-type '(windows-nt ms-dos))
+    '("--disable" "--location" "--silent" "-XPOST"
+      "-y7200" "-Y1" "-D-"))
+   ((eq system-type 'darwin)
     '("--disable" "--location" "--silent" "--compressed"
       "-XPOST" "-y7200" "-Y1" "-N" "-D-"))
+   (t
+    '("--disable" "--location" "--silent" "--compressed"
+      "-XPOST" "-y7200" "-Y1" "-D-")))
   "Arguments always passed to Curl for gptel queries.")
 
 (defvar gptel--link-type-cache nil

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -728,7 +728,7 @@ See `gptel-backend'."
       '("--disable" "--location" "--silent" "-XPOST"
         "-y7200" "-Y1" "-D-")
     '("--disable" "--location" "--silent" "--compressed"
-      "-XPOST" "-y7200" "-Y1" "-D-"))
+      "-XPOST" "-y7200" "-Y1" "-N" "-D-"))
   "Arguments always passed to Curl for gptel queries.")
 
 (defvar gptel--link-type-cache nil


### PR DESCRIPTION
LLM responses are no longer streamed for me. I bisected the issue to commit 85126d3.

It seems that curl buffers the response when stdout is a pipe. Adding `-N` (`--no-buffer`) to `gptel-curl--common-args` fixes the issue for me.

I'm not sure whether this option should be added on Windows, I cannot test it.

Thank you for your work on gptel!