### PR TITLE
Fix the name of the gptel-preset transient in gptel-rewrite (fix #1350)

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -655,7 +655,8 @@ By default, gptel uses the directive associated with the `rewrite'
      (gptel--describe-directive
       gptel--rewrite-directive (max (- (window-width) 14) 20) " "))
    [""
-    (gptel--preset
+    (gptel-preset
+     :transient t
      :if (lambda () (or (get-char-property (point) 'gptel-rewrite)
                    (use-region-p)))
      :key "@" :format "%d"


### PR DESCRIPTION
The transient suffix is gptel-preset (not gptel--preset which is a variable).