### PR TITLE
ensure newline between text and tool

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2084,10 +2084,7 @@ for tool call results.  INFO contains the state of the request."
                                  "\n")) ;start of response
                            ((not tool-marker) gptel-response-separator)
                            ((and (not (= tracking-marker tool-marker))
-                                 (save-excursion ;not consecutive tool result blocks
-                                   (goto-char tool-marker)
-                                   (skip-chars-forward " \r\t\n")
-                                   (>= (point) tracking-marker)))
+                                 (not (eq (char-before tracking-marker) ?\n)))
                             gptel-response-separator)))
                     (tool-use
                      ;; TODO(tool) also check args since there may be more than


### PR DESCRIPTION
Ensure that a newline is inserted between a text & a tool. 

Sometimes claude returns a text between two tool invocation. Currently the second tool would be on the same line as the text without a newline in between:

```
#+begin_tool (...)
#+end_tool
A text describing the tool use: #+begin_tool (...)
#+end_tool
```

This renders the second tool block invalid in org mode since it's not at the beginning of a line.

This PR ensure that we insert a separator if there is no carriage return before a tool invocation.