### PR TITLE
Ensure that gptel--ediff-restore runs after ediff-cleanup-mess

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -445,7 +445,7 @@ SWITCHES are diff arguments."
                 (funcall hideshow 'restore)
                 (remove-hook 'ediff-quit-hook gptel--ediff-restore))))
       (funcall hideshow)
-      (add-hook 'ediff-quit-hook gptel--ediff-restore)
+      (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
             (ediff-split-window-function #'split-window-horizontally))
         (ediff-buffers ov-buf newbuf)))))


### PR DESCRIPTION
By default, `ediff-cleanup-mess` is installed in `ediff-quit-hook`. Its purpose
is to delete ediff buffers such as `*Ediff Control Panel*`. The current
implementation of `gptel--rewrite-ediff` uses `(add-hook 'ediff-quit-hook
gptel--ediff-restore)` which causes `gptel--ediff-restore` (which restores the window configuration) to be run before
`ediff-cleanup-mess`. Since `ediff-cleanup-mess` expects to be run from the
control buffer, this causes it to break which results in ediff buffers not
getting cleaned up. This PR uses the depth argument of `add-hook` to fix this
problem.