### PR TITLE
gptel: fix gptel--preset-syms dropping parent-contributed symbols

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2659,9 +2659,8 @@ PRESET is the name of a preset, or a spec (plist) of the form
       (pcase key
         ((or :description :pre :post))
         (:parents
-         (mapc (lambda (parent-preset)
-                 (nconc syms (gptel--preset-syms parent-preset)))
-               (ensure-list val)))
+         (setq syms
+               (nconc syms (mapcan #'gptel--preset-syms (ensure-list val)))))
         (:system (push 'gptel--system-message syms))
         (_ (if-let* ((var (or (intern-soft
                                (concat "gptel-" (substring (symbol-name key) 1)))


### PR DESCRIPTION
`gptel--preset-syms` uses `(nconc syms ...)` to accumulate symbols from parent presets. But when `syms` is nil at that point (i.e. when `:parents` appears before other keys in the plist), `nconc` returns the new list without mutating `syms`. See https://emacs.stackexchange.com/questions/68090/nconc-does-not-seem-to-update-first-parameter-when-its-value-is-nil for a discussion.

The result is that `gptel-with-preset` silently fails to save/restore variables that come from parent presets, so they leak into the surrounding scope after the macro exits.

Fix by using `setq` around the `nconc` operation, as suggested at that SO link above.

Here's a simple repro:

```emacs-lisp
;; -*- lexical-binding: t; -*-
;;
;; To test use `emacs -q --load [filename]`.
(require 'use-package)
(use-package
 gptel
 :demand t
 :load-path "/path/to/gptel")

(let* ((parent '(:system "from-parent"))
       (child (list :parents (list parent) :use-tools t))
       (original gptel--system-message))
  (gptel-with-preset child
    (message "Inside preset: gptel--system-message=%S" gptel--system-message))
  (if (equal gptel--system-message original)
      (message "OK: gptel--system-message restored to %S" original)
    (message "BUG: gptel--system-message leaked as %S (was %S)"
             gptel--system-message original)))
```
