### PR TITLE
fix: move preset capf description to company-compatible location

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2798,11 +2798,18 @@ Add this to `completion-at-point-functions'."
              (list (point) (+ (point) num)
                    gptel--known-presets
                    :exclusive 'no
-                   :annotation-function
-                   #'(lambda (c) (thread-first
-                              (intern-soft c)
-                              (assq gptel--known-presets) (cdr)
-                              (plist-get :description)))))))))
+                   :company-doc-buffer
+                   #'(lambda (c) (let ((doc (thread-first
+                                              (intern-soft c)
+                                              (assq gptel--known-presets)
+                                              (cdr)
+                                              (plist-get :description))))
+                                    (when doc
+                                      (with-current-buffer
+                                          (get-buffer-create " *gptel-agent-doc*")
+                                        (erase-buffer)
+                                        (insert doc)
+                                        (current-buffer)))))))))))
 
 (defun gptel--prettify-preset ()
   "Get visual and completion help with presets in gptel buffers.


### PR DESCRIPTION
Closes #1356 

Example w/ corfu:

<img width="832" height="162" alt="image" src="https://github.com/user-attachments/assets/3770d606-62f9-4643-b755-490a5f861344" />
