### PR TITLE
gptel-gh: Add claude-opus-4.7 to model list

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -61,9 +61,10 @@
   =grok-4-1-fast-non-reasoning=, =grok-4-fast-reasoning=, and
   =grok-4-fast-non-reasoning=.
 
-- GitHub Copilot backend: Add support for =gpt-5.1-codex-,
-  =gpt-5.1-codex-mini, =claude-sonnet-4.6= and =gemini-3.1-pro-preview=,
-  =gpt-5.3-codex=, =gpt-5.4=, and =gpt-5.4-mini=.
+- GitHub Copilot backend: Add support for =claude-opus-4.7=,
+  =gpt-5.1-codex-, =gpt-5.1-codex-mini, =claude-sonnet-4.6= and
+  =gemini-3.1-pro-preview=, =gpt-5.3-codex=, =gpt-5.4=, and
+  =gpt-5.4-mini=.
 
 - Gemini backend: add support for =gemini-3.1-flash-lite-preview=;
   add deprecation notice for =gemini-3-pro-preview=.

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -150,6 +150,14 @@
      :input-cost 3
      :output-cost 3
      :cutoff-date "2025-03")
+    (claude-opus-4.7
+     :description "Most capable model for complex reasoning and advanced coding"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 128
+     :input-cost 3
+     :output-cost 3
+     :cutoff-date "2025-03")
     (claude-sonnet-4
      :description "High-performance model with exceptional reasoning and efficiency"
      :capabilities (media tool-use cache)


### PR DESCRIPTION
Closes #1360

GitHub Copilot now offers `claude-opus-4.7`. This PR adds it to `gptel--gh-models` with the same capabilities/properties as the existing `claude-opus-4.6` entry so it can be selected via `gptel-menu`.