### PR TITLE
Add Opus 4.7 as an Anthropic model.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,6 +57,8 @@
 
 ** New models and backends
 
+- Anthropic backend: Add support for =claude-opus-4.7=.
+
 - xAI backend: Add support for =grok-4-1-fast-reasoning=,
   =grok-4-1-fast-non-reasoning=, =grok-4-fast-reasoning=, and
   =grok-4-fast-non-reasoning=.
@@ -66,10 +68,10 @@
   =gemini-3.1-pro-preview=, =gpt-5.3-codex=, =gpt-5.4=, and
   =gpt-5.4-mini=.
 
-- Gemini backend: add support for =gemini-3.1-flash-lite-preview=;
+- Gemini backend: Add support for =gemini-3.1-flash-lite-preview=;
   add deprecation notice for =gemini-3-pro-preview=.
 
-- OpenAI backend: add support for =gpt-5.3-chat-latest=, =gpt-5.4=,
+- OpenAI backend: Add support for =gpt-5.3-chat-latest=, =gpt-5.4=,
   =gpt-5.4-pro=, =gpt-5.4-mini=, =gpt-5.4-nano=. =gpt-5.2=,
   =gpt-5-mini=, =gpt-5-nano= and =o3-pro=.
 

--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -571,7 +571,7 @@ Media files, if present, are placed in `gptel-context'."
      :description "The best combination of speed and intelligence"
      :capabilities (media tool-use cache)
      :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 200
+     :context-window 1000
      :input-cost 3
      :output-cost 15
      :cutoff-date "2025-08")

--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -599,6 +599,14 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 3
      :output-cost 15
      :cutoff-date "2025-03")
+    (claude-opus-4-7
+     :description "Most capable model for complex reasoning and advanced coding"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 1000
+     :input-cost 5
+     :output-cost 25
+     :cutoff-date "2026-01")
     (claude-opus-4-6
      :description "Most capable model for complex reasoning and advanced coding"
      :capabilities (media tool-use cache)
@@ -788,4 +796,3 @@ for."
 ;; Local Variables:
 ;; byte-compile-warnings: (not docstrings)
 ;; End:
-


### PR DESCRIPTION
This PR also corrects Sonnet 4.6's context size to 1M as per the current
Anthropic documentation.