### PR TITLE
gptel-request: Add -N flag to curl on all platforms to fix regression

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -727,13 +727,13 @@ See `gptel-backend'."
   (cond
    ((memq system-type '(windows-nt ms-dos))
     '("--disable" "--location" "--silent" "-XPOST"
-      "-y7200" "-Y1" "-D-"))
+      "-y7200" "-Y1" "-N" "-D-"))
    ((eq system-type 'darwin)
     '("--disable" "--location" "--silent" "--compressed"
       "-XPOST" "-y7200" "-Y1" "-N" "-D-"))
    (t
     '("--disable" "--location" "--silent" "--compressed"
-      "-XPOST" "-y7200" "-Y1" "-D-")))
+      "-XPOST" "-y7200" "-Y1" "-N" "-D-")))
   "Arguments always passed to Curl for gptel queries.")
 
 (defvar gptel--link-type-cache nil


### PR DESCRIPTION
The -N flag (no-buffering) was previously added for macOS in 4747ffa251af84dbb6fe181f5d2b484ec2e442a7, but
85126d398c800dfed80a91aac990a5dc0d15f9a6 caused a regression on Linux as well. I assume it's safer to add it on all platforms, not just Linux and Mac, just in case.