### PR TITLE
gptel: fix gptel-with-preset when :parents is the first keyword

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2658,7 +2658,7 @@ PRESET is the name of a preset, or a spec (plist) of the form
         ((or :description :pre :post))
         (:parents
          (mapc (lambda (parent-preset)
-                 (nconc syms (gptel--preset-syms parent-preset)))
+                 (setq syms (nconc syms (gptel--preset-syms parent-preset))))
                (ensure-list val)))
         (:system (push 'gptel--system-message syms))
         (_ (if-let* ((var (or (intern-soft


### PR DESCRIPTION
When :parents comes first in the preset definition, `syms` is nil here so `(nconc syms ...)` doesn't update `syms`.

To reproduce:

```elisp
(gptel-make-preset 'parent
  :system "parent system prompt")
(gptel-make-preset 'child
  :parents '(parent)
  :use-tools t)
(gptel--preset-syms 'child)
```