### PR TITLE
gptel-preset: allow system directives to be nil

### DIFF
--- a/gptel.el
+++ b/gptel.el
@@ -2702,7 +2702,7 @@ example) apply the preset buffer-locally."
                  (not (stringp (symbol-value sym)))
                  (user-error "Composing non-string system messages is not implemented"))
             (setq val (gptel--modify-value (symbol-value sym) val)))
-          (if (and (symbolp val) (not (functionp val)))
+          (if (and val (symbolp val) (not (functionp val)))
               (if-let* ((directive (alist-get val gptel-directives)))
                   (funcall setter sym directive)
                 (user-error "gptel preset: Cannot find directive %s" val))


### PR DESCRIPTION
Without this, emacs signals `gptel--apply-preset` signals if the preset's `system-message` (or `system`) is nil because `nil` is a valid symbol but isn't a known directive name