### PR TITLE
gptel-org: Lazy-load gptel in set-properties

### DIFF
--- a/gptel-org.el
+++ b/gptel-org.el
@@ -24,6 +24,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'gptel)
 (require 'org-element)
 (require 'outline)
 (require 'mailcap)                    ;FIXME Avoid this somehow

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -607,6 +607,7 @@ gptel model and backend names, the system message, active tools, the
 response temperature, max tokens and number of conversation turns to
 send in queries.  (See `gptel--num-messages-to-send' for the last one.)"
   (interactive (list (point) t))
+  (require 'gptel)
   (let ((preset-spec (and gptel--preset (gptel-get-preset gptel--preset))))
     (if preset-spec
         (org-entry-put pt "GPTEL_PRESET" (gptel--to-string gptel--preset))


### PR DESCRIPTION
## Summary

`gptel-org-set-properties` can be autoloaded and invoked cold (for example from Doom Emacs leader bindings). In that path, `gptel-org.el` loads without `gptel.el`, so the forward-declared gptel variables such as `gptel--preset` remain unbound and the command errors with `(void-variable gptel--preset)`.

Fixes #1370.

## Change

Lazy-load `gptel` inside `gptel-org-set-properties` before reading the active gptel configuration. This keeps `(require 'gptel-org)` lightweight while ensuring this command has the variables/functions it needs when called standalone.

## Verification

- [x] `(require 'gptel-org)` in isolation does not load `gptel`
- [x] Cold `gptel-org-set-properties` call lazily loads `gptel` and writes properties when gptel config is supplied after load
- [x] `emacs -Q --batch -L . -f batch-byte-compile gptel-org.el`
