### PR TITLE
gptel-transient: Update the transient menu after applying prefixes

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1055,7 +1055,9 @@ existing preset, as well."
                                         gptel--known-presets nil t)))))))
   (gptel--apply-preset preset
                        (or setter (lambda (sym val) (gptel--set-with-scope
-                                                sym val gptel--set-buffer-locally)))))
+                                                     sym val gptel--set-buffer-locally))))
+  (when transient--prefix
+    (transient-setup 'gptel-menu)))
 
 ;; ** Prefix for selecting tools
 


### PR DESCRIPTION
This fixes #1373.

gptel-save-preset already updates the transient when the prefix is actually
saved but currently this isn't done when it is merely applied.