### PR TITLE
Enhance gptel--rewrite-ediff as per #1351

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -422,6 +422,11 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
+(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
+                                                ("C-c C-b". accept-b))
+  "An alist of extra bindings to use in gptel ediff buffers."
+  :type '(alist :key-type string :value-type symbol))
+
 (defun gptel--rewrite-ediff (&optional ovs)
   "Ediff pending LLM responses in OVS or at point.
 
@@ -474,12 +479,17 @@ the final contents of buffer B (the edited LLM response)."
                 (gptel--rewrite-accept ovs)))
              (gptel--ediff-setup
               (lambda ()
-                (use-local-map (make-composed-keymap
-                                (define-keymap
-                                  "C-c C-a" gptel--ediff-accept-A
-                                  "C-c C-b" gptel--ediff-accept-B)
-                                (current-local-map)))
-                (message "Use C-c C-a and C-c C-b to quit ediff and immediately accept buffer A or B"))))
+                (let* ((bindings gptel-rewrite-ediff-extra-bindings)
+                       (accept-a-keys (car (rassoc 'accept-a bindings)))
+                       (accept-b-keys (car (rassoc 'accept-b bindings))))
+                  (use-local-map (make-composed-keymap
+                                  (define-keymap
+                                    accept-a-keys gptel--ediff-accept-A
+                                    accept-b-keys gptel--ediff-accept-B)
+                                  (current-local-map)))
+                  (message "Use %s and %s to quit ediff and immediately accept buffer A or B"
+                           accept-a-keys
+                           accept-b-keys)))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -431,11 +431,10 @@ ends, the contents of buffer A are preserved and the overlay in
 buffer is updated to show the contents of buffer B.
 
 Therefore, after exiting the ediff session rejecting with
-\\<gptel-rewrite-actions-map>\\[gptel--rewrite-reject] will
-result in the what was contained in buffer A at the end of the
-ediff session (the edited original buffer). Accepting with
-\\[gptel--rewrite-accept] will result in the final contents of
-buffer B (the edited LLM response)."
+\\[gptel--rewrite-reject] will result in the what was contained
+in buffer A at the end of the ediff session (the edited original
+buffer). Accepting with \\[gptel--rewrite-accept] will result in
+the final contents of buffer B (the edited LLM response)."
   (interactive (list (gptel--rewrite-overlay-at)))
   (setq ovs (ensure-list ovs))
   (when-let* ((ov-buf (overlay-buffer (car ovs)))
@@ -479,7 +478,8 @@ buffer B (the edited LLM response)."
                                 (define-keymap
                                   "C-c C-a" gptel--ediff-accept-A
                                   "C-c C-b" gptel--ediff-accept-B)
-                                (current-local-map))))))
+                                (current-local-map)))
+                (message "Use C-c C-a and C-c C-b to quit ediff and immediately accept buffer A or B"))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -424,7 +424,12 @@ SWITCHES are diff arguments."
 
 (defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
                                                 ("C-c C-b". accept-b))
-  "An alist of extra bindings to use in gptel ediff buffers."
+  "An alist of extra bindings to use in gptel ediff buffers.
+
+The symbols `accept-a' and `accept-b' are special and mean to
+quit the ediff session and accept buffer A or B. Any other
+mappings in the alist are treated as ordinary bindings to
+commands."
   :type '(alist :key-type string :value-type symbol))
 
 (defun gptel--rewrite-ediff (&optional ovs)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -501,9 +501,7 @@ the final contents of buffer B (the edited LLM response)."
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)
-      (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
-            (ediff-split-window-function #'split-window-horizontally))
-        (ediff-buffers ov-buf newbuf)))))
+      (ediff-buffers ov-buf newbuf))))
 
 (defun gptel--rewrite-merge-git (beg end new-str)
   "Produce a merge conflict region between BEG and END.

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -422,8 +422,8 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
-(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
-                                                ("C-c C-b". accept-b))
+(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a" . accept-a)
+                                                ("C-c C-b" . accept-b))
   "An alist of extra bindings to use in gptel ediff buffers.
 
 The symbols `accept-a' and `accept-b' are special and mean to

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -451,17 +451,30 @@ the final contents of buffer B (the edited LLM response)."
               ((buffer-live-p ov-buf)))
     (letrec ((newbuf (gptel--rewrite-prepare-buffer ovs))
              (cwc (current-window-configuration))
+             (response-bounds
+              (cl-loop
+               for ov in ovs
+               collect (let ((start (make-marker))
+                             (end (make-marker)))
+                         (set-marker start (overlay-start ov) newbuf)
+                         (set-marker end (+ (overlay-start ov)
+                                            (length (overlay-get ov 'gptel-rewrite)))
+                                     newbuf)
+                         (set-marker-insertion-type end t)
+                         (cons start end))))
              (hideshow
               (lambda (&optional restore)
-                (dolist (ov ovs)
-                  (when-let* ((overlay-buffer ov))
-                    (let ((response (and restore
-                                         (with-current-buffer newbuf
-                                           (buffer-string)))))
-                      (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
-                      (overlay-put ov 'display response)
-                      (when restore
-                        (overlay-put ov 'gptel-rewrite response)))))))
+                (cl-loop
+                 for ov in ovs
+                 for (start . end) in response-bounds
+                 do (when-let* ((overlay-buffer ov))
+                      (let ((response (and restore
+                                           (with-current-buffer newbuf
+                                             (buffer-substring start end)))))
+                        (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
+                        (overlay-put ov 'display response)
+                        (when restore
+                          (overlay-put ov 'gptel-rewrite response)))))))
              (gptel--ediff-restore
               (lambda ()
                 (when (window-configuration-p cwc)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -483,8 +483,6 @@ the final contents of buffer B (the edited LLM response)."
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)
-      (setq gptel--rewrite-ediff-accept-A-internal gptel--ediff-accept-A
-            gptel--rewrite-ediff-accept-B-internal gptel--ediff-accept-B)
       (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
             (ediff-split-window-function #'split-window-horizontally))
         (ediff-buffers ov-buf newbuf)))))

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -422,22 +422,39 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
+
 (defun gptel--rewrite-ediff (&optional ovs)
-  "Ediff pending LLM responses in OVS or at point."
+  "Ediff pending LLM responses in OVS or at point.
+
+During the ediff session, the original text is shown in buffer A
+and the LLM's response is shown in buffer B. When the session
+ends, the contents of buffer A are preserved and the overlay in
+buffer is updated to show the contents of buffer B.
+
+Therefore, after exiting the ediff session rejecting with
+\\<gptel-rewrite-actions-map>\\[gptel--rewrite-reject] will
+result in the what was contained in buffer A at the end of the
+ediff session (the edited original buffer). Accepting with
+\\[gptel--rewrite-accept] will result in the final contents of
+buffer B (the edited LLM response)."
   (interactive (list (gptel--rewrite-overlay-at)))
-  (when-let* ((ov-buf (overlay-buffer (or (car-safe ovs) ovs)))
+  (setq ovs (ensure-list ovs))
+  (when-let* ((ov-buf (overlay-buffer (car ovs)))
               ((buffer-live-p ov-buf)))
     (letrec ((newbuf (gptel--rewrite-prepare-buffer ovs))
              (cwc (current-window-configuration))
              (hideshow
               (lambda (&optional restore)
-                (dolist (ov (ensure-list ovs))
+                (dolist (ov ovs)
                   (when-let* ((overlay-buffer ov))
                     (let ((disp (overlay-get ov 'display))
-                          (stored (overlay-get ov 'gptel--ediff)))
+                          (response (and restore
+                                         (with-current-buffer newbuf
+                                           (buffer-string)))))
                       (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
-                      (overlay-put ov 'display (and restore stored))
-                      (overlay-put ov 'gptel--ediff (unless restore disp)))))))
+                      (overlay-put ov 'display response)
+                      (when restore
+                        (overlay-put ov 'gptel-rewrite response)))))))
              (gptel--ediff-restore
               (lambda ()
                 (when (window-configuration-p cwc)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -455,8 +455,7 @@ the final contents of buffer B (the edited LLM response)."
               (lambda (&optional restore)
                 (dolist (ov ovs)
                   (when-let* ((overlay-buffer ov))
-                    (let ((disp (overlay-get ov 'display))
-                          (response (and restore
+                    (let ((response (and restore
                                          (with-current-buffer newbuf
                                            (buffer-string)))))
                       (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -422,7 +422,6 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
-
 (defun gptel--rewrite-ediff (&optional ovs)
   "Ediff pending LLM responses in OVS or at point.
 
@@ -460,9 +459,32 @@ buffer B (the edited LLM response)."
                 (when (window-configuration-p cwc)
                   (set-window-configuration cwc))
                 (funcall hideshow 'restore)
-                (remove-hook 'ediff-quit-hook gptel--ediff-restore))))
+                (remove-hook 'ediff-quit-hook gptel--ediff-restore)
+                (remove-hook 'ediff-startup-hook gptel--ediff-setup)))
+             (gptel--ediff-accept-A
+              (lambda ()
+                (interactive)
+                ;; Pass the `current-prefix-arg' so as to mimic the behavior of
+                ;; `ediff-quit'.
+                (ediff-really-quit current-prefix-arg)
+                (gptel--rewrite-reject ovs)))
+             (gptel--ediff-accept-B
+              (lambda ()
+                (interactive)
+                (ediff-really-quit current-prefix-arg)
+                (gptel--rewrite-accept ovs)))
+             (gptel--ediff-setup
+              (lambda ()
+                (use-local-map (make-composed-keymap
+                                (define-keymap
+                                  "C-c C-a" gptel--ediff-accept-A
+                                  "C-c C-b" gptel--ediff-accept-B)
+                                (current-local-map))))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
+      (add-hook 'ediff-startup-hook gptel--ediff-setup)
+      (setq gptel--rewrite-ediff-accept-A-internal gptel--ediff-accept-A
+            gptel--rewrite-ediff-accept-B-internal gptel--ediff-accept-B)
       (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
             (ediff-split-window-function #'split-window-horizontally))
         (ediff-buffers ov-buf newbuf)))))

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -481,11 +481,15 @@ the final contents of buffer B (the edited LLM response)."
               (lambda ()
                 (let* ((bindings gptel-rewrite-ediff-extra-bindings)
                        (accept-a-keys (car (rassoc 'accept-a bindings)))
-                       (accept-b-keys (car (rassoc 'accept-b bindings))))
+                       (accept-b-keys (car (rassoc 'accept-b bindings)))
+                       (other-bindings (cl-remove-if (lambda (cell)
+                                                       (memq (cdr cell) '(accept-a accept-b)))
+                                                     bindings)))
                   (use-local-map (make-composed-keymap
-                                  (define-keymap
-                                    accept-a-keys gptel--ediff-accept-A
-                                    accept-b-keys gptel--ediff-accept-B)
+                                  (apply #'define-keymap
+                                         accept-a-keys gptel--ediff-accept-A
+                                         accept-b-keys gptel--ediff-accept-B
+                                         other-bindings)
                                   (current-local-map)))
                   (message "Use %s and %s to quit ediff and immediately accept buffer A or B"
                            accept-a-keys

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -452,17 +452,30 @@ the final contents of buffer B (the edited LLM response)."
               ((buffer-live-p ov-buf)))
     (letrec ((newbuf (gptel--rewrite-prepare-buffer ovs))
              (cwc (current-window-configuration))
+             (response-bounds
+              (cl-loop
+               for ov in ovs
+               collect (let ((start (make-marker))
+                             (end (make-marker)))
+                         (set-marker start (overlay-start ov) newbuf)
+                         (set-marker end (+ (overlay-start ov)
+                                            (length (overlay-get ov 'gptel-rewrite)))
+                                     newbuf)
+                         (set-marker-insertion-type end t)
+                         (cons start end))))
              (hideshow
               (lambda (&optional restore)
-                (dolist (ov ovs)
-                  (when-let* ((overlay-buffer ov))
-                    (let ((response (and restore
-                                         (with-current-buffer newbuf
-                                           (buffer-string)))))
-                      (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
-                      (overlay-put ov 'display response)
-                      (when restore
-                        (overlay-put ov 'gptel-rewrite response)))))))
+                (cl-loop
+                 for ov in ovs
+                 for (start . end) in response-bounds
+                 do (when-let* ((overlay-buffer ov))
+                      (let ((response (and restore
+                                           (with-current-buffer newbuf
+                                             (buffer-substring start end)))))
+                        (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
+                        (overlay-put ov 'display response)
+                        (when restore
+                          (overlay-put ov 'gptel-rewrite response)))))))
              (gptel--ediff-restore
               (lambda ()
                 (when (window-configuration-p cwc)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -425,7 +425,12 @@ SWITCHES are diff arguments."
 
 (defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
                                                 ("C-c C-b". accept-b))
-  "An alist of extra bindings to use in gptel ediff buffers."
+  "An alist of extra bindings to use in gptel ediff buffers.
+
+The symbols `accept-a' and `accept-b' are special and mean to
+quit the ediff session and accept buffer A or B. Any other
+mappings in the alist are treated as ordinary bindings to
+commands."
   :type '(alist :key-type string :value-type symbol))
 
 (defun gptel--rewrite-ediff (&optional ovs)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -423,22 +423,39 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
+
 (defun gptel--rewrite-ediff (&optional ovs)
-  "Ediff pending LLM responses in OVS or at point."
+  "Ediff pending LLM responses in OVS or at point.
+
+During the ediff session, the original text is shown in buffer A
+and the LLM's response is shown in buffer B. When the session
+ends, the contents of buffer A are preserved and the overlay in
+buffer is updated to show the contents of buffer B.
+
+Therefore, after exiting the ediff session rejecting with
+\\<gptel-rewrite-actions-map>\\[gptel--rewrite-reject] will
+result in the what was contained in buffer A at the end of the
+ediff session (the edited original buffer). Accepting with
+\\[gptel--rewrite-accept] will result in the final contents of
+buffer B (the edited LLM response)."
   (interactive (list (gptel--rewrite-overlay-at)))
-  (when-let* ((ov-buf (overlay-buffer (or (car-safe ovs) ovs)))
+  (setq ovs (ensure-list ovs))
+  (when-let* ((ov-buf (overlay-buffer (car ovs)))
               ((buffer-live-p ov-buf)))
     (letrec ((newbuf (gptel--rewrite-prepare-buffer ovs))
              (cwc (current-window-configuration))
              (hideshow
               (lambda (&optional restore)
-                (dolist (ov (ensure-list ovs))
+                (dolist (ov ovs)
                   (when-let* ((overlay-buffer ov))
                     (let ((disp (overlay-get ov 'display))
-                          (stored (overlay-get ov 'gptel--ediff)))
+                          (response (and restore
+                                         (with-current-buffer newbuf
+                                           (buffer-string)))))
                       (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))
-                      (overlay-put ov 'display (and restore stored))
-                      (overlay-put ov 'gptel--ediff (unless restore disp)))))))
+                      (overlay-put ov 'display response)
+                      (when restore
+                        (overlay-put ov 'gptel-rewrite response)))))))
              (gptel--ediff-restore
               (lambda ()
                 (when (window-configuration-p cwc)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -482,11 +482,15 @@ the final contents of buffer B (the edited LLM response)."
               (lambda ()
                 (let* ((bindings gptel-rewrite-ediff-extra-bindings)
                        (accept-a-keys (car (rassoc 'accept-a bindings)))
-                       (accept-b-keys (car (rassoc 'accept-b bindings))))
+                       (accept-b-keys (car (rassoc 'accept-b bindings)))
+                       (other-bindings (cl-remove-if (lambda (cell)
+                                                       (memq (cdr cell) '(accept-a accept-b)))
+                                                     bindings)))
                   (use-local-map (make-composed-keymap
-                                  (define-keymap
-                                    accept-a-keys gptel--ediff-accept-A
-                                    accept-b-keys gptel--ediff-accept-B)
+                                  (apply #'define-keymap
+                                         accept-a-keys gptel--ediff-accept-A
+                                         accept-b-keys gptel--ediff-accept-B
+                                         other-bindings)
                                   (current-local-map)))
                   (message "Use %s and %s to quit ediff and immediately accept buffer A or B"
                            accept-a-keys

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -423,6 +423,11 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
+(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
+                                                ("C-c C-b". accept-b))
+  "An alist of extra bindings to use in gptel ediff buffers."
+  :type '(alist :key-type string :value-type symbol))
+
 (defun gptel--rewrite-ediff (&optional ovs)
   "Ediff pending LLM responses in OVS or at point.
 
@@ -475,12 +480,17 @@ the final contents of buffer B (the edited LLM response)."
                 (gptel--rewrite-accept ovs)))
              (gptel--ediff-setup
               (lambda ()
-                (use-local-map (make-composed-keymap
-                                (define-keymap
-                                  "C-c C-a" gptel--ediff-accept-A
-                                  "C-c C-b" gptel--ediff-accept-B)
-                                (current-local-map)))
-                (message "Use C-c C-a and C-c C-b to quit ediff and immediately accept buffer A or B"))))
+                (let* ((bindings gptel-rewrite-ediff-extra-bindings)
+                       (accept-a-keys (car (rassoc 'accept-a bindings)))
+                       (accept-b-keys (car (rassoc 'accept-b bindings))))
+                  (use-local-map (make-composed-keymap
+                                  (define-keymap
+                                    accept-a-keys gptel--ediff-accept-A
+                                    accept-b-keys gptel--ediff-accept-B)
+                                  (current-local-map)))
+                  (message "Use %s and %s to quit ediff and immediately accept buffer A or B"
+                           accept-a-keys
+                           accept-b-keys)))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -423,7 +423,6 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
-
 (defun gptel--rewrite-ediff (&optional ovs)
   "Ediff pending LLM responses in OVS or at point.
 
@@ -461,9 +460,32 @@ buffer B (the edited LLM response)."
                 (when (window-configuration-p cwc)
                   (set-window-configuration cwc))
                 (funcall hideshow 'restore)
-                (remove-hook 'ediff-quit-hook gptel--ediff-restore))))
+                (remove-hook 'ediff-quit-hook gptel--ediff-restore)
+                (remove-hook 'ediff-startup-hook gptel--ediff-setup)))
+             (gptel--ediff-accept-A
+              (lambda ()
+                (interactive)
+                ;; Pass the `current-prefix-arg' so as to mimic the behavior of
+                ;; `ediff-quit'.
+                (ediff-really-quit current-prefix-arg)
+                (gptel--rewrite-reject ovs)))
+             (gptel--ediff-accept-B
+              (lambda ()
+                (interactive)
+                (ediff-really-quit current-prefix-arg)
+                (gptel--rewrite-accept ovs)))
+             (gptel--ediff-setup
+              (lambda ()
+                (use-local-map (make-composed-keymap
+                                (define-keymap
+                                  "C-c C-a" gptel--ediff-accept-A
+                                  "C-c C-b" gptel--ediff-accept-B)
+                                (current-local-map))))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
+      (add-hook 'ediff-startup-hook gptel--ediff-setup)
+      (setq gptel--rewrite-ediff-accept-A-internal gptel--ediff-accept-A
+            gptel--rewrite-ediff-accept-B-internal gptel--ediff-accept-B)
       (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
             (ediff-split-window-function #'split-window-horizontally))
         (ediff-buffers ov-buf newbuf)))))

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -456,8 +456,7 @@ the final contents of buffer B (the edited LLM response)."
               (lambda (&optional restore)
                 (dolist (ov ovs)
                   (when-let* ((overlay-buffer ov))
-                    (let ((disp (overlay-get ov 'display))
-                          (response (and restore
+                    (let ((response (and restore
                                          (with-current-buffer newbuf
                                            (buffer-string)))))
                       (overlay-put ov 'face (and restore 'gptel-rewrite-highlight-face))

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -423,8 +423,8 @@ SWITCHES are diff arguments."
         (setq-local diff-jump-to-old-file t))
       (display-buffer diff-buf))))
 
-(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a". accept-a)
-                                                ("C-c C-b". accept-b))
+(defcustom gptel-rewrite-ediff-extra-bindings '(("C-c C-a" . accept-a)
+                                                ("C-c C-b" . accept-b))
   "An alist of extra bindings to use in gptel ediff buffers.
 
 The symbols `accept-a' and `accept-b' are special and mean to

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -502,9 +502,7 @@ the final contents of buffer B (the edited LLM response)."
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)
-      (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
-            (ediff-split-window-function #'split-window-horizontally))
-        (ediff-buffers ov-buf newbuf)))))
+      (ediff-buffers ov-buf newbuf))))
 
 (defun gptel--rewrite-merge-git (beg end new-str)
   "Produce a merge conflict region between BEG and END.

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -432,11 +432,10 @@ ends, the contents of buffer A are preserved and the overlay in
 buffer is updated to show the contents of buffer B.
 
 Therefore, after exiting the ediff session rejecting with
-\\<gptel-rewrite-actions-map>\\[gptel--rewrite-reject] will
-result in the what was contained in buffer A at the end of the
-ediff session (the edited original buffer). Accepting with
-\\[gptel--rewrite-accept] will result in the final contents of
-buffer B (the edited LLM response)."
+\\[gptel--rewrite-reject] will result in the what was contained
+in buffer A at the end of the ediff session (the edited original
+buffer). Accepting with \\[gptel--rewrite-accept] will result in
+the final contents of buffer B (the edited LLM response)."
   (interactive (list (gptel--rewrite-overlay-at)))
   (setq ovs (ensure-list ovs))
   (when-let* ((ov-buf (overlay-buffer (car ovs)))
@@ -480,7 +479,8 @@ buffer B (the edited LLM response)."
                                 (define-keymap
                                   "C-c C-a" gptel--ediff-accept-A
                                   "C-c C-b" gptel--ediff-accept-B)
-                                (current-local-map))))))
+                                (current-local-map)))
+                (message "Use C-c C-a and C-c C-b to quit ediff and immediately accept buffer A or B"))))
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)

--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -484,8 +484,6 @@ the final contents of buffer B (the edited LLM response)."
       (funcall hideshow)
       (add-hook 'ediff-quit-hook gptel--ediff-restore 50)
       (add-hook 'ediff-startup-hook gptel--ediff-setup)
-      (setq gptel--rewrite-ediff-accept-A-internal gptel--ediff-accept-A
-            gptel--rewrite-ediff-accept-B-internal gptel--ediff-accept-B)
       (let ((ediff-window-setup-function #'ediff-setup-windows-plain)
             (ediff-split-window-function #'split-window-horizontally))
         (ediff-buffers ov-buf newbuf)))))


### PR DESCRIPTION
gptel--rewrite-ediff has been changed so that the LLM response overlays are set
to the contents of buffer B when ediff quits. The contents of buffer A are still
the actual contents of the original buffer before the LLM edit (not the text
shown by the overlays). Additionally, `C-c C-a` and `C-c C-b` bindings have been
added to ediff to immediately quit and accept a buffer.

~The keymap should really be configurable but its inconvenient with the current
code since there isn't a convenient way to bind the local functions in
`defvar-keymap` form. It could be refactored of course but using several global
functions seems ugly compared to the current letrec implementation.~

Edit: a configuration option has now been added for the bindings.