### PR TITLE
gptel-openai-extras: update costs for deepseek-chat and deepseek-reasoner

### DIFF
--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -315,13 +315,13 @@ The Deepseek API requires strictly alternating roles (user/assistant) in message
           (models '((deepseek-reasoner
                      :capabilities (tool reasoning)
                      :context-window 128
-                     :input-cost 0.28
-                     :output-cost 0.42)
+                     :input-cost 0.14
+                     :output-cost 0.28)
                     (deepseek-chat
                      :capabilities (tool)
                      :context-window 128
-                     :input-cost 0.28
-                     :output-cost 0.42)
+                     :input-cost 0.14
+                     :output-cost 0.28)
 		    (deepseek-v4-flash
                      :capabilities (tool reasoning)
                      :context-window 1000


### PR DESCRIPTION
As per the Deepseek docs, deepseek-chat and deepseek-reasoner are the
non-thinking and thinking modes of deepseek-v4-flash respectively. Thus, their
prices should be the same as deepseek-v4-flash. Note that Deepseek states that
these models will eventually be deprecated.