### PR TITLE
gh: add gpt-5.5 to Copilot models

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,9 +67,9 @@
   =grok-4-fast-non-reasoning=.
 
 - GitHub Copilot backend: Add support for =claude-opus-4.7=,
-  =gpt-5.1-codex-, =gpt-5.1-codex-mini, =claude-sonnet-4.6= and
-  =gemini-3.1-pro-preview=, =gpt-5.3-codex=, =gpt-5.4=, and
-  =gpt-5.4-mini=.
+  =gpt-5.1-codex-, =gpt-5.1-codex-mini, =claude-sonnet-4.6=,
+  =gemini-3.1-pro-preview=, =gpt-5.3-codex=, =gpt-5.4=,
+  =gpt-5.4-mini=, and =gpt-5.5=.
 
 - Gemini backend: Add support for =gemini-3.1-flash-lite-preview=;
   add deprecation notice for =gemini-3-pro-preview=.

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -126,6 +126,14 @@
      :input-cost 0.33
      :output-cost 0.33
      :cutoff-date "2025-08")
+    (gpt-5.5
+     :description "GitHub Copilot GPT-5.5"
+     :capabilities (media tool-use json url responses-api)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+     :context-window 400
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2026-04")
     (claude-haiku-4.5
      :description "Near-frontier intelligence at blazing speeds with extended thinking"
      :capabilities (media tool-use cache)


### PR DESCRIPTION
## Summary
- Add `gpt-5.5` to the GitHub Copilot model list in `gptel-gh.el`
- Mark it as Responses API-capable, matching recent Copilot GPT-5.x models

## Testing
- Ran an Emacs batch smoke test against the local checkout to load `gptel-gh`, create a Copilot backend, set `gptel-model` to `gpt-5.5`, and verify request construction uses `:model "gpt-5.5"`.

Output:
```text
PASS: gpt-5.5 present; request model="gpt-5.5"
request data=(:model "gpt-5.5" :input ["Test prompt"] :store :json-false :stream :json-false :instructions "You are a large language model living in Emacs and a helpful assistant. Respond concisely." :temperature 1.0)
```

Also tested interactively with GitHub Copilot access; `gpt-5.5` works.