### PR TITLE
fix: Ensure utf-8 in tool call args

### DIFF
--- a/gptel-openai-responses.el
+++ b/gptel-openai-responses.el
@@ -126,7 +126,9 @@ information if the stream contains it."
                                     :call_id (plist-get tc :id)
                                     :name (plist-get tc :name)
                                     :arguments
-                                    (gptel--json-encode (plist-get tc :args))))
+                                    (decode-coding-string
+                                     (gptel--json-encode (plist-get tc :args))
+                                     'utf-8 t)))
                             tool-use)))
                  (when-let* ((resp (plist-get data :response)))
                    (plist-put info :stop-reason (plist-get resp :status))


### PR DESCRIPTION
* gptel-openai-responses.el (gptel-curl--parse-stream): Fix `json-value-p` error when a tool receives for example unicode characters as tool function arguments.