### PR TITLE
Dedicated reasoning text property

### DIFF
--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -101,8 +101,10 @@ information if the stream contains it.  Not my best work, I know."
                       (plist-put info :reasoning
                                  (concat (plist-get info :reasoning) thinking))
                     (if-let* ((signature (plist-get delta :signature)))
-                        (plist-put info :signature
-                                   (concat (plist-get info :signature) signature))))))))
+                        (progn
+                          (plist-put info :signature signature)
+                          (plist-put info :reasoning-metadata
+                                     (list :signature signature)))))))))
 
            ((looking-at "content_block_start") ;Is the following block text or tool-use?
             (forward-line 1) (forward-char 5)
@@ -115,6 +117,10 @@ information if the stream contains it.  Not my best work, I know."
                                                    :input nil) ;ensure :input key is always present
                                              (plist-get info :tool-use))))
                 ("thinking" (plist-put info :reasoning (plist-get cblock :thinking))
+                 (when-let* ((signature (plist-get cblock :signature)))
+                   (plist-put info :signature signature)
+                   (plist-put info :reasoning-metadata
+                              (list :signature signature)))
                  (plist-put info :reasoning-block 'in)))))
 
            ((looking-at "content_block_stop")
@@ -200,6 +206,8 @@ Mutate state INFO with response metadata."
     info :reasoning
     (concat (plist-get info :reasoning)
             (plist-get cblock :thinking)))
+   (when-let* ((signature (plist-get cblock :signature)))
+     (plist-put info :reasoning-metadata (list :signature signature)))
    finally do
    (when tool-use
      ;; First, add the tool call to the prompts list
@@ -426,6 +434,48 @@ for details.  This implementation handles the Anthropic API."
              '(:cache_control (:type "ephemeral"))))
     full-prompt))
 
+(defun gptel--anthropic-thinking-block (text metadata)
+  "Return an Anthropic thinking block for TEXT and METADATA."
+  (nconc (list :type "thinking" :thinking text)
+         (when-let* ((signature (plist-get metadata :signature)))
+           (list :signature signature))))
+
+(defun gptel--anthropic-attach-reasoning (prompts text metadata)
+  "Attach Anthropic reasoning TEXT with METADATA to PROMPTS."
+  (let* ((signature (plist-get metadata :signature))
+         (message (and (equal (plist-get (car prompts) :role) "assistant")
+                       (car prompts)))
+         (content (and message (plist-get message :content)))
+         (first-block (and (vectorp content) (> (length content) 0)
+                           (aref content 0)))
+         (merge-block (and first-block
+                           (equal (plist-get first-block :type) "thinking")
+                           (equal (plist-get first-block :signature)
+                                  signature)
+                           first-block))
+         (text (if merge-block text (gptel--trim-prefixes text))))
+    (unless (string-blank-p text)
+      (cond
+       (merge-block
+        (plist-put merge-block :thinking
+                   (concat text (plist-get merge-block :thinking))))
+       (message
+        (plist-put
+         message :content
+         (vconcat
+          (vector (gptel--anthropic-thinking-block text metadata))
+          (cond
+           ((stringp content) (vector (list :type "text" :text content)))
+           ((vectorp content) content)
+           (content (vector content))
+           (t [])))))
+       (t
+        (push (list :role "assistant"
+                    :content
+                    (vector (gptel--anthropic-thinking-block text metadata)))
+              prompts)))))
+  prompts)
+
 (cl-defmethod gptel--parse-buffer ((backend gptel-anthropic) &optional max-entries)
   (let ((prompts) (prev-pt (point)))
     (if (or gptel-mode gptel-track-response)
@@ -446,6 +496,12 @@ for details.  This implementation handles the Anthropic API."
                              (buffer-substring-no-properties (point) prev-pt))))
                  (when (not (string-blank-p content))
                    (push (list :role "assistant" :content content) prompts))))
+              (`(reasoning . ,metadata)
+               (setq prompts
+                     (gptel--anthropic-attach-reasoning
+                      prompts
+                      (buffer-substring-no-properties (point) prev-pt)
+                      metadata)))
               (`(tool . ,id)
                (save-excursion
                  (condition-case nil

--- a/gptel-openai-responses.el
+++ b/gptel-openai-responses.el
@@ -50,6 +50,41 @@ USAGE is part of the response, INFO is the request plist."
                    (gptel--sum-plists (plist-get info :tokens-full)
                                       tokens))))))
 
+(defun gptel--openai-responses-reasoning-metadata (item)
+  "Return persisted reasoning metadata from Responses API ITEM."
+  (nconc
+   (when-let* ((id (plist-get item :id))
+               ((not (eq id :null))))
+     (list :id id))
+   (when-let* ((encrypted (plist-get item :encrypted_content))
+               ((not (eq encrypted :null))))
+     (list :encrypted_content encrypted))))
+
+(defun gptel--openai-responses-reasoning-text (item)
+  "Return visible reasoning summary/content text from Responses API ITEM."
+  (cl-loop with summary = (plist-get item :summary)
+           with content = (plist-get item :content)
+           for part across (cond
+                            ((and (vectorp content) (> (length content) 0))
+                             content)
+                            ((vectorp summary) summary)
+                            (t []))
+           for text = (plist-get part :text)
+           when (stringp text)
+           collect text into texts
+           finally return (apply #'concat texts)))
+
+(defun gptel--openai-responses-add-include (data include)
+  "Add INCLUDE to Responses request DATA without duplicating it."
+  (let* ((existing (plist-get data :include))
+         (items (cond
+                 ((vectorp existing) (append existing nil))
+                 ((listp existing) existing)
+                 ((and existing (not (eq existing :null))) (list existing)))))
+    (unless (member include items)
+      (setq items (append items (list include))))
+    (plist-put data :include (vconcat items))))
+
 (cl-defmethod gptel-curl--parse-stream ((_backend gptel-openai-responses) info)
   "Parse an OpenAI Responses API data stream.
 
@@ -67,6 +102,14 @@ information if the stream contains it."
               (forward-char 5)
               (setq data (gptel--json-read))
               (pcase event-type
+                ;; Output item starts
+                ("response.output_item.added"
+                 (when-let* ((item (plist-get data :item))
+                             ((equal (plist-get item :type) "reasoning")))
+                   (plist-put info :reasoning-block nil)
+                   (plist-put info :reasoning nil)
+                   (plist-put info :reasoning-metadata
+                              (gptel--openai-responses-reasoning-metadata item))))
                 ;; Text content delta
                 ("response.output_text.delta"
                  (when-let* ((delta (plist-get data :delta))
@@ -80,16 +123,27 @@ information if the stream contains it."
                 ;; Function call completed (user-defined tools)
                 ("response.output_item.done"
                  (when-let* ((item (plist-get data :item))
-                             ((equal (plist-get item :type) "function_call"))
-                             (tool-call
-                              (list :id (plist-get item :call_id)
-                                    :name (plist-get item :name)
-                                    :args (ignore-errors
-                                            (gptel--json-read-string
-                                             (plist-get item :arguments))))))
-                   (plist-put info :tool-use
-                              (cons tool-call (plist-get info :tool-use)))
-                   (plist-put info :partial_json nil)))
+                             (type (plist-get item :type)))
+                   (pcase type
+                     ("function_call"
+                      (when-let* ((tool-call
+                                   (list :id (plist-get item :call_id)
+                                         :name (plist-get item :name)
+                                         :args (ignore-errors
+                                                 (gptel--json-read-string
+                                                  (plist-get item :arguments))))))
+                        (plist-put info :tool-use
+                                   (cons tool-call (plist-get info :tool-use)))
+                        (plist-put info :partial_json nil)))
+                     ("reasoning"
+                      (let ((metadata
+                             (gptel--openai-responses-reasoning-metadata item)))
+                        (plist-put info :reasoning-metadata metadata)
+                        (when (and (plist-get metadata :encrypted_content)
+                                   (or (not (stringp (plist-get info :reasoning)))
+                                       (string-empty-p (plist-get info :reasoning))))
+                          (plist-put info :reasoning " "))
+                        (plist-put info :reasoning-block t))))))
                 ;; Reasoning content
                 ((or "response.reasoning_summary_text.delta"
                      "response.reasoning.delta")
@@ -98,7 +152,7 @@ information if the stream contains it."
                               (concat (plist-get info :reasoning) delta))))
                 ((or "response.reasoning_summary_text.done"
                      "response.reasoning.done")
-                 (plist-put info :reasoning-block t))
+                 nil)
                 ;; NOTE: backend tools are not supported in gptel yet, this
                 ;; parsing is for the future
                 ;; Web search completed (server-side tool)
@@ -171,13 +225,12 @@ Mutate state INFO with response metadata."
               tool-use))
        ;; Reasoning summary
        ("reasoning"
-        (cl-loop with summary = (plist-get item :summary)
-                 with content = (plist-get item :content)
-                 for s across
-                 (if (length= content 0) summary content)
-                 collect (plist-get s :text) into reasoning
-                 finally do
-                 (plist-put info :reasoning (apply #'concat reasoning))))
+        (let* ((text (gptel--openai-responses-reasoning-text item))
+               (metadata (gptel--openai-responses-reasoning-metadata item)))
+          (plist-put info :reasoning-items
+                     (append (plist-get info :reasoning-items)
+                             (list (cons (if (string-empty-p text) " " text)
+                                         metadata))))))
        ;; Web search results (server-side tool)
        ("web_search_call"
         (when-let* ((status (plist-get item :status))
@@ -251,11 +304,13 @@ Mutate state INFO with response metadata."
                                       (gptel--dispatch-schema-type gptel--schema))
                              :strict t))))
     ;; Merge request params
-    (gptel--merge-plists
-     prompts-plist
-     gptel--request-params
-     (gptel-backend-request-params gptel-backend)
-     (gptel--model-request-params gptel-model))))
+    (let ((data (gptel--merge-plists
+                 prompts-plist
+                 gptel--request-params
+                 (gptel-backend-request-params gptel-backend)
+                 (gptel--model-request-params gptel-model))))
+      (gptel--openai-responses-add-include
+       data "reasoning.encrypted_content"))))
 
 ;; Helper functions for Responses API format conversion
 
@@ -405,6 +460,16 @@ If POSITION is
              if text collect
              (list :role (if role "user" "assistant") :content text))))
 
+(defun gptel--openai-responses-reasoning-item (metadata)
+  "Return a Responses API reasoning input item from METADATA."
+  (when-let* ((encrypted-content (plist-get metadata :encrypted_content)))
+    (nconc
+     (list :type "reasoning")
+     (when-let* ((id (plist-get metadata :id)))
+       (list :id id))
+     (list :summary []
+           :encrypted_content encrypted-content))))
+
 (cl-defmethod gptel--parse-buffer ((backend gptel-openai-responses) &optional max-entries)
   (let ((prompts) (prev-pt (point)))
     (if (or gptel-mode gptel-track-response)
@@ -417,6 +482,9 @@ If POSITION is
              (when-let* ((content (gptel--trim-prefixes
                                    (buffer-substring-no-properties (point) prev-pt))))
                (push (list :role "assistant" :content content) prompts)))
+            (`(reasoning . ,metadata)
+             (when-let* ((item (gptel--openai-responses-reasoning-item metadata)))
+               (push item prompts)))
             (`(tool . ,id)
              (save-excursion
                (condition-case nil

--- a/gptel-openai-responses.el
+++ b/gptel-openai-responses.el
@@ -91,14 +91,6 @@ information if the stream contains it."
               (forward-char 5)
               (setq data (gptel--json-read))
               (pcase event-type
-                ;; Output item starts
-                ("response.output_item.added"
-                 (when-let* ((item (plist-get data :item))
-                             ((equal (plist-get item :type) "reasoning")))
-                   (plist-put info :reasoning-block nil)
-                   (plist-put info :reasoning nil)
-                   (plist-put info :reasoning-metadata
-                              (gptel--openai-responses-reasoning-metadata item))))
                 ;; Text content delta
                 ("response.output_text.delta"
                  (when-let* ((delta (plist-get data :delta))
@@ -112,27 +104,16 @@ information if the stream contains it."
                 ;; Function call completed (user-defined tools)
                 ("response.output_item.done"
                  (when-let* ((item (plist-get data :item))
-                             (type (plist-get item :type)))
-                   (pcase type
-                     ("function_call"
-                      (when-let* ((tool-call
-                                   (list :id (plist-get item :call_id)
-                                         :name (plist-get item :name)
-                                         :args (ignore-errors
-                                                 (gptel--json-read-string
-                                                  (plist-get item :arguments))))))
-                        (plist-put info :tool-use
-                                   (cons tool-call (plist-get info :tool-use)))
-                        (plist-put info :partial_json nil)))
-                     ("reasoning"
-                      (let ((metadata
-                             (gptel--openai-responses-reasoning-metadata item)))
-                        (plist-put info :reasoning-metadata metadata)
-                        (when (and (plist-get metadata :encrypted_content)
-                                   (or (not (stringp (plist-get info :reasoning)))
-                                       (string-empty-p (plist-get info :reasoning))))
-                          (plist-put info :reasoning " "))
-                        (plist-put info :reasoning-block t))))))
+                             ((equal (plist-get item :type) "function_call"))
+                             (tool-call
+                              (list :id (plist-get item :call_id)
+                                    :name (plist-get item :name)
+                                    :args (ignore-errors
+                                            (gptel--json-read-string
+                                             (plist-get item :arguments))))))
+                   (plist-put info :tool-use
+                              (cons tool-call (plist-get info :tool-use)))
+                   (plist-put info :partial_json nil)))
                 ;; Reasoning content
                 ((or "response.reasoning_summary_text.delta"
                      "response.reasoning.delta")
@@ -141,7 +122,7 @@ information if the stream contains it."
                               (concat (plist-get info :reasoning) delta))))
                 ((or "response.reasoning_summary_text.done"
                      "response.reasoning.done")
-                 nil)
+                 (plist-put info :reasoning-block t))
                 ;; NOTE: backend tools are not supported in gptel yet, this
                 ;; parsing is for the future
                 ;; Web search completed (server-side tool)

--- a/gptel-openai-responses.el
+++ b/gptel-openai-responses.el
@@ -74,17 +74,6 @@ USAGE is part of the response, INFO is the request plist."
            collect text into texts
            finally return (apply #'concat texts)))
 
-(defun gptel--openai-responses-add-include (data include)
-  "Add INCLUDE to Responses request DATA without duplicating it."
-  (let* ((existing (plist-get data :include))
-         (items (cond
-                 ((vectorp existing) (append existing nil))
-                 ((listp existing) existing)
-                 ((and existing (not (eq existing :null))) (list existing)))))
-    (unless (member include items)
-      (setq items (append items (list include))))
-    (plist-put data :include (vconcat items))))
-
 (cl-defmethod gptel-curl--parse-stream ((_backend gptel-openai-responses) info)
   "Parse an OpenAI Responses API data stream.
 
@@ -274,6 +263,9 @@ Mutate state INFO with response metadata."
             ;; Stateless: don't store responses server-side, don't use
             ;; previous_response_id. Each request contains full context.
             :store :json-false
+            ;; The above requires `encrypted_content' to be included. See
+            ;; https://developers.openai.com/api/docs/guides/reasoning?example=refactoring#encrypted-reasoning-items
+            :include ["reasoning.encrypted_content"]
             :stream ,(or gptel-stream :json-false)))
         (o-model-p (memq gptel-model '(o1 o1-preview o1-mini o3-mini o3 o4-mini))))
     ;; System message becomes instructions
@@ -304,13 +296,11 @@ Mutate state INFO with response metadata."
                                       (gptel--dispatch-schema-type gptel--schema))
                              :strict t))))
     ;; Merge request params
-    (let ((data (gptel--merge-plists
-                 prompts-plist
-                 gptel--request-params
-                 (gptel-backend-request-params gptel-backend)
-                 (gptel--model-request-params gptel-model))))
-      (gptel--openai-responses-add-include
-       data "reasoning.encrypted_content"))))
+    (gptel--merge-plists
+     prompts-plist
+     gptel--request-params
+     (gptel-backend-request-params gptel-backend)
+     (gptel--model-request-params gptel-model))))
 
 ;; Helper functions for Responses API format conversion
 

--- a/gptel-openai.el
+++ b/gptel-openai.el
@@ -362,6 +362,16 @@ If the ID has the format used by a different backend, use as-is."
              if text collect
              (list :role (if role "user" "assistant") :content text))))
 
+(defun gptel--openai-attach-reasoning (prompts text)
+  "Attach reasoning TEXT to PROMPTS in OpenAI chat format."
+  (if (equal (plist-get (car prompts) :role) "assistant")
+      (plist-put (car prompts) :reasoning_content
+                 (concat text (plist-get (car prompts) :reasoning_content)))
+    (push (list :role "assistant" :content :null
+                :reasoning_content text)
+          prompts))
+  prompts)
+
 (cl-defmethod gptel--parse-buffer ((backend gptel-openai) &optional max-entries)
   (let ((prompts) (prev-pt (point)))
     (if (or gptel-mode gptel-track-response)
@@ -374,6 +384,10 @@ If the ID has the format used by a different backend, use as-is."
              (when-let* ((content (gptel--trim-prefixes
                                    (buffer-substring-no-properties (point) prev-pt))))
                (push (list :role "assistant" :content content) prompts)))
+            (`(reasoning . ,_)
+             (setq prompts
+                   (gptel--openai-attach-reasoning
+                    prompts (buffer-substring-no-properties (point) prev-pt))))
             (`(tool . ,id)
              (save-excursion
                (condition-case nil

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2603,8 +2603,12 @@ the response is inserted into the current buffer after point."
                              (plist-put info :status http-msg)
                              (gptel--fsm-transition fsm) ;WAIT -> TYPE
                              (when error (plist-put info :error error))
-                             (when response ;Look for a reasoning block
-                               (if (string-match-p "^\\s-*<think>" response)
+                             (when (or response
+                                       (plist-get info :reasoning)
+                                       (plist-get info :reasoning-items))
+                               ;; Look for a reasoning block
+                               (if (and (stringp response)
+                                        (string-match-p "^\\s-*<think>" response))
                                    (when-let* ((idx (string-search "</think>" response)))
                                      (with-demoted-errors "gptel callback error: %S"
                                        (funcall callback
@@ -2613,9 +2617,7 @@ the response is inserted into the current buffer after point."
                                                 info))
                                      (setq response (string-trim-left
                                                      (substring response (+ idx 8)))))
-                                 (when-let* ((reasoning (plist-get info :reasoning))
-                                             ((stringp reasoning)))
-                                   (funcall callback (cons 'reasoning reasoning) info))))
+                                 (gptel--dispatch-reasoning callback info)))
                              (when (or response (not (member http-status '("200" "100"))))
                                (with-demoted-errors "gptel callback error: %S"
                                  (funcall callback response info)))
@@ -2641,6 +2643,23 @@ RESPONSE is the parsed JSON of the response, as a plist.
 
 PROC-INFO is a plist with process information and other context.
 See `gptel-curl--get-response' for its contents.")
+
+(defun gptel--dispatch-reasoning (callback info)
+  "Call CALLBACK for reasoning content stored in INFO.
+
+Backends that need per-block metadata can set :reasoning-items to
+a list of (TEXT . META) cells.  Simpler backends can set :reasoning and
+optionally :reasoning-metadata."
+  (if-let* ((items (plist-get info :reasoning-items)))
+      (progn
+        (dolist (item items)
+          (plist-put info :reasoning-metadata (cdr item))
+          (funcall callback (cons 'reasoning (car item)) info))
+        (plist-put info :reasoning-items nil)
+        (plist-put info :reasoning-metadata nil))
+    (when-let* ((reasoning (plist-get info :reasoning))
+                ((stringp reasoning)))
+      (funcall callback (cons 'reasoning reasoning) info))))
 
 (defun gptel--url-parse-response (backend proc-info)
   "Parse response from BACKEND with PROC-INFO."
@@ -3036,9 +3055,9 @@ PROCESS and _STATUS are process parameters."
                                proc-info))
                     (setq response
                           (string-trim-left (substring response (+ idx 8)))))
-                (when-let* ((reasoning (plist-get proc-info :reasoning))
-                            ((stringp reasoning)))
-                  (funcall proc-callback (cons 'reasoning reasoning) proc-info)))
+                (when (or (plist-get proc-info :reasoning)
+                          (plist-get proc-info :reasoning-items))
+                  (gptel--dispatch-reasoning proc-callback proc-info)))
               ;; Call callback with response text
               (when (or response (not (member http-status '("200" "100"))))
                 (with-demoted-errors "gptel callback error: %S"

--- a/gptel.el
+++ b/gptel.el
@@ -622,7 +622,7 @@ Link failed to validate, see `gptel-markdown-validate-link' or `gptel-org-valida
           (when-let* ((prop (get-char-property (point) 'gptel)))
             (let* ((prop-name (if (symbolp prop) prop (car prop)))
                    (val (when (consp prop) (cdr prop)))
-                   (bound (if val
+                   (bound (if (consp prop)
                               (list (point) prev-pt val)
                             (list (point) prev-pt))))
               (push bound (alist-get prop-name bounds))))
@@ -1119,23 +1119,25 @@ must be set."
 (defun gptel-highlight--margin-prefix (type)
   "Create margin prefix string for TYPE.
 
-Supported TYPEs are response, ignore and tool calls."
+Supported TYPEs are response, reasoning, ignore and tool calls."
   (propertize ">" 'display
               `( (margin left-margin)
                  ,(propertize "▎" 'face
                               (pcase type
-                                ('response 'gptel-response-fringe-highlight)
+                                ((or 'response `(reasoning . ,_))
+                                 'gptel-response-fringe-highlight)
                                 ('ignore 'shadow)
                                 (`(tool . ,_) 'shadow))))))
 
 (defun gptel-highlight--fringe-prefix (type)
   "Create fringe prefix string for TYPE.
 
-Supported TYPEs are response, ignore and tool calls."
+Supported TYPEs are response, reasoning, ignore and tool calls."
   (propertize ">" 'display
               `( left-fringe gptel-highlight-fringe
                  ,(pcase type
-                    ('response 'gptel-response-fringe-highlight)
+                    ((or 'response `(reasoning . ,_))
+                     'gptel-response-fringe-highlight)
                     ('ignore 'shadow)
                     (`(tool . ,_) 'shadow)))))
 
@@ -1146,7 +1148,7 @@ Supported TYPEs are response, ignore and tool calls."
   (when (memq 'face gptel-highlight-methods)
     (overlay-put ov 'font-lock-face
                  (pcase val
-                   ('response 'gptel-response-highlight)
+                   ((or 'response `(reasoning . ,_)) 'gptel-response-highlight)
                    ('ignore 'shadow)
                    (`(tool . ,_) 'shadow))))
   (when-let* ((prefix
@@ -1167,7 +1169,7 @@ BEG and END delimit the region to refresh."
                               (point) 'gptel nil beg))
                   (/= (point) prev-pt))
         (pcase (get-char-property (point) 'gptel)
-          ((and (or 'response 'ignore `(tool . ,_)) val)
+          ((and (or 'response 'ignore `(tool . ,_) `(reasoning . ,_)) val)
            (if-let* ((ov (or (cdr-safe (get-char-property-and-overlay
                                         (point) 'gptel-highlight))
                              (cdr-safe (get-char-property-and-overlay
@@ -1819,7 +1821,12 @@ Optional RAW disables text properties and transformation."
                      (gptel--insert-response
                       (concat (car blocks) text (cdr blocks)) info t))
                  (gptel--insert-response (concat separator (car blocks)) info t)
-                 (gptel--insert-response text info)
+                 (add-text-properties
+                  0 (length text)
+                  `(gptel (reasoning . ,(plist-get info :reasoning-metadata))
+                          front-sticky (gptel))
+                  text)
+                 (gptel--insert-response text info t)
                  (gptel--insert-response (cdr blocks) info t))
                (save-excursion
                  (goto-char (plist-get info :tracking-marker))
@@ -1955,6 +1962,8 @@ for streaming responses only."
         (with-current-buffer (marker-buffer start-marker)
           (if (eq text t)               ;end of stream
               (progn
+                (when-let* ((prop (plist-get info :reasoning-property)))
+                  (setcdr prop (plist-get info :reasoning-metadata)))
                 (gptel-curl--stream-insert-response
                  (concat (if (derived-mode-p 'org-mode)
                              "\n#+end_reasoning"
@@ -1972,6 +1981,8 @@ for streaming responses only."
                                  (org-cycle)))
                       (when (re-search-backward "^```" start-marker t)
                         (gptel-markdown-cycle-block))))))
+                (plist-put info :reasoning-property nil)
+                (plist-put info :reasoning-marker nil)
             (unless (and reasoning-marker tracking-marker
                          (= reasoning-marker tracking-marker))
               (let ((separator        ;Separate from response prefix if required
@@ -1992,7 +2003,16 @@ for streaming responses only."
                   (add-text-properties
                    0 (length text) '(gptel ignore front-sticky (gptel)) text)
                   (gptel-curl--stream-insert-response text info t))
-              (gptel-curl--stream-insert-response text info)))
+              (let ((prop (or (plist-get info :reasoning-property)
+                              (let ((cell (cons 'reasoning
+                                                (plist-get info :reasoning-metadata))))
+                                (plist-put info :reasoning-property cell)
+                                cell))))
+                (add-text-properties
+                 0 (length text)
+                 `(gptel ,prop front-sticky (gptel))
+                 text)
+                (gptel-curl--stream-insert-response text info t))))
           (setq tracking-marker (plist-get info :tracking-marker))
           (if reasoning-marker
               (move-marker reasoning-marker tracking-marker)

--- a/gptel.el
+++ b/gptel.el
@@ -1980,9 +1980,9 @@ for streaming responses only."
                                (when (looking-at "^#\\+end_reasoning")
                                  (org-cycle)))
                       (when (re-search-backward "^```" start-marker t)
-                        (gptel-markdown-cycle-block))))))
+                        (gptel-markdown-cycle-block)))))
                 (plist-put info :reasoning-property nil)
-                (plist-put info :reasoning-marker nil)
+                (plist-put info :reasoning-marker nil))
             (unless (and reasoning-marker tracking-marker
                          (= reasoning-marker tracking-marker))
               (let ((separator        ;Separate from response prefix if required


### PR DESCRIPTION
Hey @karthink 

Disclaimer first: The code was modified with the help of GPT 5.5

The idea of this PR is to add a `reasoning` text property and add backend specific handling for reasoning.

The text property is a cons of the form `(reasoning . PLIST)`:

  ```elisp
;; Anthropic
  (reasoning . (:signature "SIGNATURE"))

  ;; OpenAI Messages
  (reasoning . nil)

  ;; OpenAI Responses
  (reasoning . (:id "rs_..." :encrypted_content "ENCRYPTED_CONTENT"))
```

I have chosen a plist so it can be extended in the future if other properties need to be preserved as well.

This PR would close/fix:
- #1391 (`encrypted_content` enabled and handled according to [docs](https://developers.openai.com/api/docs/guides/reasoning?example=refactoring#encrypted-reasoning-items))
- Resolve (at least partially) #1326 and #1232
- #1383

It would be great if you would consider this and provide some feedback on how to improve this PR. GPT 5.5 likes to refactor code into little helper functions and as I do not know your stance on this, I let the code be for now.
I also only targeted the three backends above, probably this needs to get extended to others as well?

From my initial testing I can say that it seems to work.

One drawback seen so far: 
- Anthropic APIs can reject the prompt if signatures are not valid. This can happen when you switch models (lets say GLM -> Claude) and send reasoning content which was generated by GLM to Claude. That should at least be documented.

Potential follow ups:
- https://developers.openai.com/api/docs/guides/reasoning?example=refactoring#phase-parameter mentions that the `phase` parameter should be added as well and that skipping it [can degrade performance](https://developers.openai.com/api/reference/resources/responses/methods/retrieve#(resource)%20responses%20%3E%20(model)%20response_output_message%20%3E%20(schema)%20%3E%20(property)%20phase):

```
phase: optional "commentary" or "final_answer"

Labels an assistant message as intermediate commentary (commentary) or the final answer (final_answer). For models like gpt-5.3-codex and beyond, when sending follow-up requests, preserve and resend phase on all assistant messages — dropping it can degrade performance. Not used for user messages.
```