### PR TITLE
Fix OpenAI responses reasoning block closing too early

### DIFF
--- a/gptel-openai-responses.el
+++ b/gptel-openai-responses.el
@@ -67,6 +67,12 @@ information if the stream contains it."
               (forward-char 5)
               (setq data (gptel--json-read))
               (pcase event-type
+                ;; Output item starts
+                ("response.output_item.added"
+                 (when-let* ((item (plist-get data :item))
+                             ((equal (plist-get item :type) "reasoning")))
+                   (plist-put info :reasoning-block nil)
+                   (plist-put info :reasoning nil)))
                 ;; Text content delta
                 ("response.output_text.delta"
                  (when-let* ((delta (plist-get data :delta))
@@ -80,16 +86,20 @@ information if the stream contains it."
                 ;; Function call completed (user-defined tools)
                 ("response.output_item.done"
                  (when-let* ((item (plist-get data :item))
-                             ((equal (plist-get item :type) "function_call"))
-                             (tool-call
-                              (list :id (plist-get item :call_id)
-                                    :name (plist-get item :name)
-                                    :args (ignore-errors
-                                            (gptel--json-read-string
-                                             (plist-get item :arguments))))))
-                   (plist-put info :tool-use
-                              (cons tool-call (plist-get info :tool-use)))
-                   (plist-put info :partial_json nil)))
+                             (type (plist-get item :type)))
+                   (pcase type
+                     ("function_call"
+                      (when-let* ((tool-call
+                                   (list :id (plist-get item :call_id)
+                                         :name (plist-get item :name)
+                                         :args (ignore-errors
+                                                 (gptel--json-read-string
+                                                  (plist-get item :arguments))))))
+                        (plist-put info :tool-use
+                                   (cons tool-call (plist-get info :tool-use)))
+                        (plist-put info :partial_json nil)))
+                     ("reasoning"
+                      (plist-put info :reasoning-block t)))))
                 ;; Reasoning content
                 ((or "response.reasoning_summary_text.delta"
                      "response.reasoning.delta")
@@ -98,7 +108,7 @@ information if the stream contains it."
                               (concat (plist-get info :reasoning) delta))))
                 ((or "response.reasoning_summary_text.done"
                      "response.reasoning.done")
-                 (plist-put info :reasoning-block t))
+                 nil)
                 ;; NOTE: backend tools are not supported in gptel yet, this
                 ;; parsing is for the future
                 ;; Web search completed (server-side tool)


### PR DESCRIPTION
This fixes a bug in the OpenAI Responses API which caused `resoning` blocks get closed too early:
```
Which planet has the highest distance in the solar distance from the earth and from the sun?


  #+begin_reasoning
  **Clarifying planetary distances**

  The question seems to ask which planet is the farthest from Earth and the Sun. When it comes to the greatest distance from the Sun, it's Neptune. As for
  Earth, the maximum distance varies with orbital positions, but typically, Neptune is the farthest planet. Its average distance is about 30 AU, and when on
  the opposite side from Earth, it can reach about 31 AU. Uranus is also far but not as much as Neptune. I should clarify if dwarf planets like Pluto are
  included in the question.**Calculating planet distances**

  I
  #+end_reasoning <- HERE

   could include approximate distances for clarity. From the Sun, Neptune is about 4.5 billion km, which is roughly 30 AU. As for its distance from Earth, it
  varies between 4.3 and 4.7 billion km, translating to about 28.8 to 31 AU. The maximum distance from Earth is around 4.7 billion km, while the minimum is
  about 4.3 billion km. I’ll strive to present this information concisely for clarity.
   #+end_reasoning <- HERE

  The planet farthest from both the Sun and Earth is *Neptune*.

  - *From the Sun:* about *4.5 billion km* on average
  - *From Earth:* varies with orbit, about *4.3 to 4.7 billion km*

  Note: *Pluto* is farther away at times, but it is classified as a *dwarf planet*, not a planet.
```
