### PR TITLE
Bedrock Claude Opus 4.7

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@
 
 ** Breaking changes
 ** New models and backends
+
+- Bedrock backend: Add support for =claude-opus-4-7=.
+
 ** New features and UI changes
 ** Notable bug fixes
 

--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -600,6 +600,7 @@ Convenient to use with `cl-multiple-value-bind'"
   ;; https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
   '((claude-sonnet-4-6           . "anthropic.claude-sonnet-4-6")
     (claude-opus-4-6             . "anthropic.claude-opus-4-6-v1")
+    (claude-opus-4-7             . "anthropic.claude-opus-4-7")
     (claude-sonnet-4-5-20250929  . "anthropic.claude-sonnet-4-5-20250929-v1:0")
     (claude-haiku-4-5-20251001   . "anthropic.claude-haiku-4-5-20251001-v1:0")
 	(claude-opus-4-5-20251101    . "anthropic.claude-opus-4-5-20251101-v1:0")


### PR DESCRIPTION
Added Claude Opus 4.7 model ID to Bedrock model list.

Based on https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html.