### PR TITLE
gptel-rewrite: remove default face from overlay display

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -556,7 +556,7 @@ INFO is the async communication channel for the rewrite request."
           (insert response)
           (unless (eobp) (ignore-errors (delete-char (length response))))
           (font-lock-ensure)
-          (overlay-put ov 'display (propertize (buffer-string) 'face 'default))))
+          (overlay-put ov 'display (propertize (buffer-string)))))
       (unless (plist-get info :stream) (gptel--rewrite-callback t info)))
 
      ((eq response 'abort)              ;request aborted


### PR DESCRIPTION
A previous commit added the 'default' face to the overlay's display property. This causes the pre-rewrite text to look identical to the post-rewrite text, which prevents to see where the cursor is positioned during inference streaming.

The keyboard can't scroll and that can't be fixed in gptel, but at least the mouse wheel can scroll with scroll-preserve-screen-position so it'd be nice to retain the visibility of the inference progress while the text doesn't change.

Fixes: 992161fd06eb ("gptel-rewrite: Confirm tool calls from minibuffer")