### PR TITLE
gptel-rewrite: Only use string-pixel-width on graphic display

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -216,7 +216,8 @@ which see."
            (propertize " Waiting..." 'face '(warning default)) ;status element 1
            (propertize                                         ;status element 2
             " " 'display
-            (if (fboundp 'string-pixel-width)
+            (if (and (fboundp 'string-pixel-width)
+                     (display-graphic-p))
                 `(space :align-to (- right (,(string-pixel-width hint-str))))
               `(space :align-to (- right ,(+ 1 (string-width hint-str))))))
            (propertize hint-str 'face '(warning default)))) ;status element 3

--- a/gptel.el
+++ b/gptel.el
@@ -933,7 +933,8 @@ Search between BEG and END."
         (concat
          (propertize
           " " 'display
-          (if (fboundp 'string-pixel-width)
+          (if (and (fboundp 'string-pixel-width)
+                   (display-graphic-p))
               `(space :align-to (- right (,(string-pixel-width rhs))))
             `(space :align-to (- right ,(+ 5 (string-width rhs))))))
          rhs))))


### PR DESCRIPTION
This returns the string-width on non-graphic displays which necessitates the +1 so it doesn't overflow

Fixes https://github.com/karthink/gptel/issues/1406