### PR TITLE
gptel-request: Improve error messages on failed curl requests

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2678,7 +2678,9 @@ See `gptel-curl--get-response' for its contents.")
                 (string-trim resp))
               http-status http-msg))
        ((and-let* ((error-data
-                    (cond ((plistp response) (plist-get response :error))
+                    (cond ((plistp response) (or (plist-get response :error)
+                                                 (plist-get response :message)
+                                                 (plist-get response :Message)))
                           ((arrayp response)
                            (cl-some (lambda (el) (plist-get el :error)) response)))))
           (list nil http-status http-msg error-data)))
@@ -2899,7 +2901,10 @@ PROCESS and _STATUS are process parameters."
                                           (condition-case nil (gptel--json-read)
                                             (error 'json-read-error))))
                          (error-data
-                          (cond ((plistp response) (plist-get response :error))
+                          (cond ((plistp response)
+                                 (or (plist-get response :error)
+                                     (plist-get response :message)
+                                     (plist-get response :Message)))
                                 ((arrayp response)
                                  (cl-some (lambda (el) (plist-get el :error)) response)))))
               (cond
@@ -3093,7 +3098,9 @@ PROC-INFO is a plist with contextual information."
                       (string-trim resp))
                     http-status http-msg))
              ((and-let* ((error-data
-                          (cond ((plistp response) (plist-get response :error))
+                          (cond ((plistp response) (or (plist-get response :error)
+                                                       (plist-get response :message)
+                                                       (plist-get response :Message)))
                                 ((arrayp response)
                                  (cl-some (lambda (el) (plist-get el :error)) response)))))
                 (list nil http-status http-msg error-data)))


### PR DESCRIPTION
I'm using AWS Bedrock which sometimes returns a json body of `{"message":"..."}` this handles that case. Ultimately this means that the message in the minibuffer is now clearer, e.g.:

```
;; New message:
Bedrock error: (HTTP/2 403) The security token included in the request is expired
;; Old message:
Bedrock error: ((HTTP/2 403) Could not parse HTTP response.) Could not parse HTTP response.
```

There are two other locations where the same thing is done, so this might be needed. As yet I've not hit those code paths. But for reference they are in `gptel--url-parse-response` and `gptel-curl--steam-cleanup`.