### PR TITLE
gptel-bedrock: Fix multi-turn tool use in gptel--parse-buffer

### DIFF
--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -409,10 +409,46 @@ MAX-ENTRIES is the maximum number of prompts to include."
                       (/= prev-pt (point-min))
                       (goto-char (previous-single-property-change
                                   (point) 'gptel nil (point-min))))
-            (capture-prompt (pcase (get-char-property (point) 'gptel)
-                              ('response "assistant")
-                              ('nil "user"))
-                            (point) prev-pt)
+            ;; Skip blank regions (e.g. response separators) to avoid
+            ;; capturing empty content that JSON-encodes as {}.
+            (unless (save-excursion (skip-syntax-forward " ") (>= (point) prev-pt))
+              (pcase (get-char-property (point) 'gptel)
+                ('response
+                 (capture-prompt "assistant" (point) prev-pt))
+                (`(tool . ,id)
+                 ;; Reconstruct the toolUse (assistant) and toolResult (user)
+                 ;; message pair from the serialized tool call text in the buffer.
+                 (save-excursion
+                   (condition-case nil
+                       (let* ((tool-call (read (current-buffer)))
+                              (name (plist-get tool-call :name))
+                              (args (plist-get tool-call :args))
+                              (result (string-trim
+                                       (buffer-substring-no-properties
+                                        (point) prev-pt))))
+                         ;; user message: toolResult (pushed first, ends up second)
+                         (push (list :role "user"
+                                     :content
+                                     `[(:toolResult (:toolUseId ,id
+                                                     :status "success"
+                                                     :content [(:text ,result)]))])
+                               prompts)
+                         ;; assistant message: toolUse (pushed second, ends up first)
+                         (push (list :role "assistant"
+                                     :content
+                                     `[(:toolUse (:toolUseId ,id
+                                                  :name ,name
+                                                  :input ,args))])
+                               prompts))
+                     ((end-of-file invalid-read-syntax)
+                      (message "gptel: Could not parse tool-call %s on line %s"
+                               id (line-number-at-pos (point)))))))
+                ('ignore)
+                ('nil
+                 (let ((text (gptel--trim-prefixes
+                              (buffer-substring-no-properties (point) prev-pt))))
+                   (unless (or (null text) (string-blank-p text))
+                     (capture-prompt "user" (point) prev-pt))))))
             (setq prev-pt (point))
             (cl-decf max-entries))
         (capture-prompt "user" (point-min) (point-max)))


### PR DESCRIPTION
## Fix multi-turn tool use for the Bedrock backend

### Problem

TLDR: The new pattern of including tool results in buffers doesn't work with Bedrock.

After a tool call, subsequent requests to the Bedrock backend are malformed.  `gptel--parse-buffer` reconstructs the conversation history by walking backwards through the buffer, but it only handles two text property values on buffer regions: `response` (→ `"assistant"`) and `nil` (→ `"user"`).

Tool call regions are propertized with `(tool . <id>)`, which has no matching arm in the `pcase`.  This causes two bugs:

1. *Wrong role*: `(tool . id)` falls through to `nil`, so the role  becomes Lisp `nil`, which JSON-encodes as `{}` instead of a string.

2. *Spurious empty user messages*: `gptel-response-separator` regions  between turns have a `nil` `gptel` property, so they were also  captured as user messages.  Their whitespace-only content trims to `nil`, which JSON-encodes as `{}`, This produces bogus `{"role": "user", "content": [{"text": {}}]}` message.

Both problems cause the Bedrock API to reject the request on the second and subsequent turns whenever a tool had been called with the message "Start of structure or map found where not expected".

### Fix

- Add a `(tool . ,id)` arm to the `pcase` in `gptel--parse-buffer` that reads the serialized `(:name ... :args ...)` plist and result  text from the buffer and reconstructs the proper `toolUse` (assistant) / `toolResult` (user) message pair required by the Bedrock Converse API.

- Wrap the `pcase` in a blank-region guard (`skip-syntax-forward " "`) so that whitespace-only regions are
  skipped entirely, matching the approach already used by the Anthropic backend.

- Add an additional nil-and-blank check on the `nil` (user) arm as an extra guard against any remaining edge cases.