### PR TITLE
gptel-gemini: Add gemini-3.1-flash-lite and deprecate the preview

### DIFF
--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -477,8 +477,19 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 2.0                    ; 4.0 for >200k tokens
      :output-cost 12.00                 ; 18.0 for >200k tokens
      :cutoff-date "2025-01")
+    (gemini-3.1-flash-lite
+     :description "Most cost-efficient multimodal Gemini model, offering the fastest performance for high-frequency, lightweight tasks"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 1048
+     :input-cost 0.25
+     :output-cost 1.50
+     :cutoff-date "2025-01")
     (gemini-3.1-flash-lite-preview
-     :description "Nost cost-efficient multimodal Gemini model, offering the fastest performance for high-frequency, lightweight tasks"
+     :description "DEPRECATED: The model will be shut down on May 25, 2026. Please use gemini-3.1-flash-lite instead"
      :capabilities (tool-use json media audio video)
      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
                   "application/pdf" "text/plain" "text/csv" "text/html"


### PR DESCRIPTION
The Gemini 3.1 Flash Lite Preview model will be discontinued on May 25, 2026. The General Availability version should be the same but called `gemini-3.1-flash-lite`.