### PR TITLE
gptel-request: Fix major-mode init in prompt-buffer copy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,9 @@
 - Fix bounds issues when using the gptel transient menu with =evil-mode=
   visual selections.
 
+- Fix org-mode parsing issues involving =tab-width= when sending
+  queries.
+
 * 0.9.9.5 2026-05-03
 
 ** Breaking changes

--- a/gptel-org.el
+++ b/gptel-org.el
@@ -285,6 +285,8 @@ depend on the value of `gptel-org-branching-context', which see."
                 (gptel-org--strip-elements))
               (setq org-complex-heading-regexp ;For org-element-context to run
                     (buffer-local-value 'org-complex-heading-regexp org-buf))
+              (setq tab-width      ;Match source indentation for list parsing
+                    (buffer-local-value 'tab-width org-buf))
               (current-buffer))))
       ;; Create prompt the usual way
       (let ((org-buf (current-buffer))
@@ -298,6 +300,8 @@ depend on the value of `gptel-org-branching-context', which see."
                 (gptel-org--strip-elements))
           (setq org-complex-heading-regexp ;For org-element-context to run
                 (buffer-local-value 'org-complex-heading-regexp org-buf))
+          (setq tab-width      ;Match source indentation for list parsing
+                (buffer-local-value 'tab-width org-buf))
           (current-buffer))))))
 
 (defun gptel-org--strip-elements ()


### PR DESCRIPTION

## Problem

`gptel--with-buffer-copy-internal` (gptel-request.el:959) sets the prompt buffer's `major-mode` symbol via `setq` without running the mode function or its hooks:

```elisp
(setq major-mode (buffer-local-value 'major-mode buf))
```

For many modes this is fine — the symbol alone is enough for downstream code to dispatch on. For `org-mode` it's not. `org-mode`'s function body sets buffer-local invariants that `org-element` relies on, including `tab-width = 8`. With only the symbol set, the buffer enters `org-mode` *nominally* but inherits the global default `tab-width` instead (4 in many configs, including mine).

When `gptel--parse-buffer` → `gptel--parse-media-links` → `org-element-at-point` runs on such a prompt buffer, Org's `org-element--list-struct` raises:

```
org-element--list-struct: Tab width in Org files must be 8, not 4.
Please adjust your `tab-width' settings for Org mode
```

## Repro

Easiest trigger I found: any caller whose `:buffer` has `major-mode = org-mode` and whose prompt contains list-shaped content. The case I hit:

1. `(setq git-commit-major-mode 'org-mode)` (commits-as-org users).
2. Run `gptel-magit-generate-message` (from `gptel-magit`) on a diff that contains `*Example:*` lines or `- bulleted` lists — i.e., content that `org-element--list-struct` actually parses.
3. The error fires before the HTTP request goes out.

Backtrace (abridged):

```
error("Tab width in Org files must be 8, not %d ..." 4)
org-element--list-struct(107772)
org-element--parse-to(26275)
org-element-at-point()
org-element-context()
gptel--parse-media-links(org-mode 1 107772)
gptel--parse-buffer(...)
gptel--realize-query(...)
gptel-request(...)
```

The same bug would fire from any caller whose source buffer is in `org-mode` (a `gptel-send` from an org file with the right content shape, an org-based agent file, etc.).

## Fix

Call the mode function under `delay-mode-hooks` so the mode body sets its buffer-local invariants (including `tab-width`), but the user-facing hooks don't fire in the transient prompt buffer:

```elisp
(delay-mode-hooks
  (funcall (buffer-local-value 'major-mode buf)))
```

This is a one-line change. The mode function body runs (so `tab-width=8` lands for `org-mode`, etc.), but `org-mode-hook`, `text-mode-hook`, and `after-change-major-mode-hook` are batched and never fired — appropriate for a temp buffer that's killed shortly after.

## Why not just call `(funcall major-mode)` without delay?

That works too, but it fires user hooks in the temp buffer. Some hooks have non-trivial side effects (font-lock, file watchers, autocomplete setup, custom timers). `delay-mode-hooks` is the lighter option and matches the original intent of "just enough mode init."

## Why not set `tab-width` only?

A narrower fix would be `(setq-local tab-width 8)` when the source is `org-mode`. It works for this specific symptom but doesn't generalize — any other buffer-local that an org-mode-derived parser relies on would still be missing. Calling the mode function properly is the structural fix.

## Test coverage

The downstream consumer in my config has a regression test that:

1. Sets the global default `tab-width` to 4.
2. Creates a temp buffer in `org-mode`.
3. Calls `gptel--with-buffer-copy-internal`.
4. Inside `body-thunk`, asserts `tab-width = 8`.

Without the fix, the test fails (recorded `tab-width = 4`). With the fix, it passes.

## Patch

```diff
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -956,7 +956,8 @@ For BUF, START, END and BODY-THUNK see `gptel--with-buffer-copy'."
                       gptel-temperature gptel-max-tokens gptel-cache))
         (set (make-local-variable sym) (buffer-local-value sym buf)))
       (when (and start end) (insert-buffer-substring buf start end))
-      (setq major-mode (buffer-local-value 'major-mode buf))
+      (delay-mode-hooks
+        (funcall (buffer-local-value 'major-mode buf)))
       (funcall body-thunk))))
```
