### PR TITLE
fix: gptel--realize-query prompt can get deleted

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -2235,8 +2235,9 @@ be used to rerun or continue the request at a later time."
   "Realize the query payload for FSM from its prompt buffer.
 
 Initiate the request when done."
-  (let ((info (gptel-fsm-info fsm)))
-    (with-current-buffer (plist-get info :data)
+  (let* ((info (gptel-fsm-info fsm))
+         (prompt-buffer (plist-get info :data)))
+    (with-current-buffer prompt-buffer
       (let* ((directive (gptel--parse-directive gptel--system-message 'raw))
              ;; DIRECTIVE contains both the system message and the template prompts
              (gptel--system-message
@@ -2277,8 +2278,9 @@ Initiate the request when done."
         (when (and gptel-use-tools gptel-tools)
           (plist-put info :tools gptel-tools))
         (plist-put info :data
-                   (gptel--request-data gptel-backend full-prompt)))
-      (kill-buffer (current-buffer)))
+                   (gptel--request-data gptel-backend full-prompt))))
+    (when (buffer-live-p prompt-buffer)
+      (kill-buffer prompt-buffer))
     ;; INIT -> WAIT
     (unless (plist-get info :dry-run) (gptel--fsm-transition fsm))
     fsm))


### PR DESCRIPTION
This fixes an edge case in `gptel--realize-query` which surfaced mainly due to my personal emacs config using `persp-mode` and custom popup window system: 

In `gptel--realize-query` it is assumed that the prompt buffer stays selected while the function runs and  `(kill-buffer (current-buffer))` points to it. 
Under certain (rare, crazy...) circumstances, `current-buffer` changes and points towards an already killed one and thus, this function errors.

This PR makes the selection of prompt buffer explicit. 