### PR TITLE
bedrock: strip the filename suffix when sending documents

### DIFF
--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -503,7 +503,7 @@ The output is a vector of entries in Bedrock API format."
              `(:image (:format ,(cdr format) :source (:bytes ,(gptel--base64-encode media)))))
             ((setq format (assoc mime gptel-bedrock--doc-formats))
              `(:document (:format ,(cdr format)
-                          :name ,(file-name-nondirectory media)
+                          :name ,(file-name-sans-extension (file-name-nondirectory media))
                           :source (:bytes ,(gptel--base64-encode media)))))
             (t (error "Unsupported MIME type %s for AWS Bedrock" mime))))
           (textfile `(:text ,(with-temp-buffer


### PR DESCRIPTION
fixes #1427

this turned out to be trivial.