### PR TITLE
gptel-gemini: Add support for gemini-3.5-flash

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,8 +21,10 @@
 
 - Bedrock backend: Add support for =claude-opus-4-7=.
 
-- Gemini backend: Add support for =gemini-3.1-flash-lite= and deprecate
-  the preview version.
+- GitHub Copilot backend: Add support for =gemini-3.5-flash=.
+
+- Gemini backend: Add support for =gemini-3.5-flash=,
+  =gemini-3.1-flash-lite= and deprecate the preview version.
 
 ** New features and UI changes
 

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -466,6 +466,17 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 0.10
      :output-cost 0.40
      :cutoff-date "2025-01")
+    (gemini-3.5-flash
+     :description "Most intelligent Gemini model for sustained frontier performance in agentic and coding tasks"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 1048               ; 65536 output token limit
+     :input-cost 1.50
+     :output-cost 9.00
+     :cutoff-date "2025-01")
     (gemini-3.1-pro-preview
      :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
      :capabilities (tool-use json media audio video)

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -232,6 +232,17 @@
      :input-cost 1
      :output-cost 1
      :cutoff-date "2025-01")
+    (gemini-3.5-flash
+     :description "Most intelligent Gemini model for sustained frontier performance in agentic and coding tasks"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 109
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2025-01")
     (grok-code-fast-1
      :description "Fast reasoning model for agentic coding"
      :capabilities '(tool-use json reasoning)


### PR DESCRIPTION
This PR adds support for the `gemini-3.5-flash` model across standard Gemini and GitHub backends, including capabilities, MIME types, costs, and news documentation.

Ref: https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5