### PR TITLE
gptel-bedrock: Support system and tool prompt caching

### DIFF
--- a/gptel-bedrock.el
+++ b/gptel-bedrock.el
@@ -84,11 +84,17 @@ back to the LLM)."
   (let ((base-request-data
          (nconc
           `(:messages [,@prompts] :inferenceConfig (:maxTokens ,(or gptel-max-tokens 500)))
-          (when gptel--system-message `(:system [(:text ,gptel--system-message)]))
+          (when gptel--system-message
+            `(:system [(:text ,gptel--system-message)
+                       ,@(when (or (eq gptel-cache t) (memq 'system gptel-cache))
+                           '((:cachePoint (:type "default"))))]))
           (when gptel-temperature `(:temperature ,gptel-temperature))
           (when (and gptel-use-tools gptel-tools)
             `(:toolConfig (:toolChoice ,(if (eq gptel-use-tools 'force) '(:any '()) '(:auto '()))
-                           :tools ,(gptel--parse-tools backend gptel-tools)))))))
+                           :tools ,(let ((tools (gptel--parse-tools backend gptel-tools)))
+                                     (if (or (eq gptel-cache t) (memq 'tool gptel-cache))
+                                         (vconcat tools [(:cachePoint (:type "default"))])
+                                       tools))))))))
 
     ;; Finally, merge all potential :request-params sources.
     (gptel--merge-plists


### PR DESCRIPTION
**The problem:** While `gptel--bedrock-update-tokens` already tracked `cacheReadInputTokens` and `cacheWriteInputTokens` from Bedrock responses, prompt caching was never actually being activated — no `:cachePoint` block was included in requests. This meant the cache fields in responses were always zero.

**This fix:** Two caching scenarios are now supported, controlled by `gptel-cache`:

- **System prompt caching** — when `gptel-cache` is `t` or includes the symbol `system`, a `:cachePoint` block is appended to the system message in the request body.
- **Tool caching** — when `gptel-cache` is `t` or includes the symbol `tool`, a `:cachePoint` block is appended as the final entry in the `:tools` array inside `:toolConfig`.

In both cases the cache point type is `"default"`, as required by the Bedrock Converse API.

See: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html