### PR TITLE
gptel-openai-oauth: add model gpt-5.5

### DIFF
--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -222,7 +222,7 @@ before constructing the headers."
           (protocol "https")
           (endpoint "/backend-api/codex/responses")
           (models 
-           '(gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini gpt-5.4)))
+           '(gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini gpt-5.4 gpt-5.5)))
   "Register a ChatGPT Plus/Pro OAuth backend for gptel with NAME.
 
 This backend uses ChatGPT OAuth tokens (not OpenAI API keys) and


### PR DESCRIPTION
Noticed this one was missing.