### PR TITLE
gptel-request: Unify error handling and cover all keywords in arrays

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1256,6 +1256,23 @@ returned as a list of strings."
                            (gptel--parse-list
                             gptel-backend (cdr directive))))))))
 
+;;;; Error handling
+(defun gptel--parse-response-plist-error (response)
+  "Extract errors from RESPONSE when it is a plist.
+
+Return nil if no error occurred."
+  (or (plist-get response :error)     ; generic
+      (plist-get response :detail)    ; openai-oauth
+      (plist-get response :message)   ; bedrock
+      (plist-get response :Message))) ; bedrock
+
+(defun gptel--parse-response-error (response)
+  "Extract errors from RESPONSE.
+
+Return nil if no error occurred."
+  (cond ((plistp response) (gptel--parse-response-plist-error response))
+        ((arrayp response)
+         (cl-some #'gptel--parse-response-plist-error response))))
 
 ;;; Logging
 
@@ -2715,13 +2732,7 @@ See `gptel-curl--get-response' for its contents.")
                          ((not (string-blank-p resp))))
                 (string-trim resp))
               http-status http-msg))
-       ((and-let* ((error-data
-                    (cond ((plistp response) (or (plist-get response :error)     ; generic
-                                                 (plist-get response :detail)    ; openai-oauth
-                                                 (plist-get response :message)   ; bedrock
-                                                 (plist-get response :Message))) ; bedrock
-                          ((arrayp response)
-                           (cl-some (lambda (el) (plist-get el :error)) response)))))
+       ((and-let* ((error-data (gptel--parse-response-error response)))
           (list nil http-status http-msg error-data)))
        ((eq response 'json-read-error)
         (list nil http-status (concat "(" http-msg ") Malformed JSON in response.") "json-read-error"))
@@ -2939,14 +2950,7 @@ PROCESS and _STATUS are process parameters."
                          (response (progn (goto-char header-size)
                                           (condition-case nil (gptel--json-read)
                                             (error 'json-read-error))))
-                         (error-data
-                          (cond ((plistp response)
-                                 (or (plist-get response :error)     ; generic
-                                     (plist-get response :detail)    ; openai-oauth
-                                     (plist-get response :message)   ; bedrock
-                                     (plist-get response :Message))) ; bedrock
-                                ((arrayp response)
-                                 (cl-some (lambda (el) (plist-get el :error)) response)))))
+                         (error-data (gptel--parse-response-error response)))
               (cond
                (error-data
                 (plist-put info :error error-data))
@@ -3137,13 +3141,7 @@ PROC-INFO is a plist with contextual information."
                                ((not (string-blank-p resp))))
                       (string-trim resp))
                     http-status http-msg))
-             ((and-let* ((error-data
-                          (cond ((plistp response) (or (plist-get response :error)     ; generic
-                                                       (plist-get response :detail)    ; openai-oauth
-                                                       (plist-get response :message)   ; bedrock
-                                                       (plist-get response :Message))) ; bedrock
-                                ((arrayp response)
-                                 (cl-some (lambda (el) (plist-get el :error)) response)))))
+             ((and-let* ((error-data (gptel--parse-response-error response)))
                 (list nil http-status http-msg error-data)))
              ((eq response 'json-read-error)
               (list nil http-status (concat "(" http-msg ") Malformed JSON in response.")


### PR DESCRIPTION
There is currently a bug with Codex (using gptel-openai-oauth.el) that causes
the reasons for some errors to be omitted. For example, when attempting to use
gpt-5.4-nano with Codex an error occurs because the model is not supported but
the reason is not shown. This is because when the response is an array only the
:error keyword is checked but Codex uses :detail.

Rather then insert :detail in yet another spot and add more duplicate code, I've
added a separate function for extracting errors and replaced the copies of

    (cond ((plistp response)
           (or (plist-get response :error)     ; generic
               (plist-get response :detail)    ; openai-oauth
               (plist-get response :message)   ; bedrock
               (plist-get response :Message))) ; bedrock
          ((arrayp response)
           (cl-some (lambda (el) (plist-get el :error)) response)))

with it.