### PR TITLE
gptel-anthropic: Add claude fable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,7 +31,8 @@
 - Bedrock backend: Add support for =claude-opus-4-7= and
   =claude-opus-4-8=.
 
-- Anthropic backend: Add support for =claude-opus-4-8=.
+- Anthropic backend: Add support for =claude-opus-4-8= and
+  =claude-fable-5=.
 
 - GitHub Copilot backend: Add support for =gemini-3.5-flash=.
 

--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -598,6 +598,14 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 3
      :output-cost 15
      :cutoff-date "2025-03")
+    (claude-fable-5
+     :description "Most capable model for complex reasoning and advanced coding"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 1000
+     :input-cost 10
+     :output-cost 50
+     :cutoff-date "2026-01")
     (claude-opus-4-8
      :description "Most capable model for complex reasoning and advanced coding"
      :capabilities (media tool-use cache)


### PR DESCRIPTION
Note: the knowledge cutoff date was not included at https://platform.claude.com/docs/en/about-claude/models/overview but comes from this source: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html