### PR TITLE
Add the Vertex AI API support for Anthropic backend

### DIFF
--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -38,7 +38,8 @@
 ;;; Anthropic (Messages API)
 (cl-defstruct (gptel-anthropic (:constructor gptel--make-anthropic)
                                (:copier nil)
-                               (:include gptel-backend)))
+                               (:include gptel-backend))
+  (uses-vertex-ai nil))
 
 (defun gptel--anthropic-update-tokens (usage info)
   "Update token usage information from USAGE.
@@ -223,12 +224,16 @@ Mutate state INFO with response metadata."
 (cl-defmethod gptel--request-data ((backend gptel-anthropic) prompts)
   "JSON encode PROMPTS for sending to ChatGPT."
   (let ((prompts-plist
-         `( :model ,(gptel--model-name gptel-model)
-            :stream ,(or gptel-stream :json-false)
+         `( :stream ,(or gptel-stream :json-false)
             :max_tokens ,(or gptel-max-tokens 4096)
             :messages [,@prompts]))
         (cachep (and (or (eq gptel-cache t) (memq 'system gptel-cache))
                      (gptel--model-capable-p 'cache))))
+    ;; The Vertex AI API specifies the model in the endpoint URL, not
+    ;; in the request body.  Thus, let's not specify the model in the
+    ;; requet body if we are using the Vertex AI API.
+    (when (not (gptel-anthropic-uses-vertex-ai backend))
+      (plist-put prompts-plist :model (gptel--model-name gptel-model)))
     (when gptel-system-prompt
       ;; gptel-system-prompt is a string or a list of strings
       (plist-put
@@ -691,7 +696,8 @@ URL `https://docs.anthropic.com/en/docs/about-claude/models#model-comparison-tab
           (models gptel--anthropic-models)
           (host "api.anthropic.com")
           (protocol "https")
-          (endpoint "/v1/messages"))
+          (endpoint "/v1/messages")
+          (uses-vertex-ai nil))
   "Register an Anthropic API-compatible backend for gptel with NAME.
 
 Keyword arguments:
@@ -728,6 +734,11 @@ PROTOCOL (optional) specifies the protocol, https by default.
 ENDPOINT (optional) is the API endpoint for completions, defaults to
 \"/v1/messages\".
 
+USES-VERTEX-AI (optional) is a boolean to toggle support for using
+anthropic models through the Google Cloud Platform.  That platform uses
+the Vertex AI API which specifies the model in the endpoint URL rather
+than in the body of the request.  This is set to nil by default.
+
 HEADER (optional) is for additional headers to send with each
 request.  It should be an alist or a function that retuns an
 alist, like:
@@ -754,7 +765,8 @@ for."
                   :request-params request-params
                   :url (if protocol
                            (concat protocol "://" host endpoint)
-                         (concat host endpoint)))))
+                         (concat host endpoint))
+                  :uses-vertex-ai uses-vertex-ai)))
     (prog1 backend
       (setf (alist-get name gptel--known-backends
                        nil nil #'equal)


### PR DESCRIPTION
Google Cloud Platform's Vertex AI provides access to Anthropic's Claude models through a wrapper API that differs slightly from Anthropic's direct API.  The key differences are:

1. The model identifier is embedded in the endpoint URL rather than in the request body
2. Vertex AI rejects requests that include a "model" field in the JSON payload with an "Extra inputs are not permitted" error
3. Authentication uses Google Cloud OAuth tokens instead of Anthropic API keys

This patch adds a `uses-vertex-ai` flag to the `gptel-anthropic` backend structure that, when enabled, prevents the "model" field from being added to API requests. This allows gptel to work seamlessly with Claude models accessed through Vertex AI.

An example configuration for the Vertex AI API in a user's Emacs configuration would be:

  (setq gptel-backend
        (gptel-make-anthropic "VertexAI"
          :uses-vertex-ai t
          :header (lambda ()
                    (let ((token (string-trim
                                  (shell-command-to-string
                                   "gcloud auth print-access-token"))))
                      `(("Authorization" . ,(concat "Bearer " token)))))
          :stream t
          :host "<insert-region-here>-aiplatform.googleapis.com"
          :request-params '(:anthropic_version "vertex-2023-10-16")
          :endpoint (format "/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict"
                            "YOUR-PROJECT-ID"
                            "<insert-region-here>"
                            gptel-model)))

The `uses-vertex-ai` parameter defaults to nil, maintaining backward compatibility with existing Anthropic API configurations.

        * gptel-anthropic.el (gptel-anthropic): Add `uses-vertex-ai` slot
        to the structure.
        (gptel--request-data): Conditionally omit the `:model` field from the
        request plist when `uses-vertex-ai` is non-nil.
        (gptel-make-anthropic): Add `uses-vertex-ai` keyword parameter and
        pass it to the backend constructor.