### PR TITLE
gptel-gh: Add GitHub Copilot support for claude-opus-4.8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,7 +34,8 @@
 - Anthropic backend: Add support for =claude-opus-4-8= and
   =claude-fable-5=.
 
-- GitHub Copilot backend: Add support for =gemini-3.5-flash=.
+- GitHub Copilot backend: Add support for =gemini-3.5-flash= and
+  =claude-opus-4.8=.
 
 - Gemini backend: Add support for =gemini-3.5-flash=,
   =gemini-3.1-flash-lite= and deprecate the preview version.

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -166,6 +166,14 @@
      :input-cost 3
      :output-cost 3
      :cutoff-date "2025-03")
+    (claude-opus-4.8
+     :description "Most capable model for complex reasoning and advanced coding"
+     :capabilities (media tool-use cache)
+     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
+     :context-window 128
+     :input-cost 3
+     :output-cost 3
+     :cutoff-date "2025-03")
     (claude-sonnet-4
      :description "High-performance model with exceptional reasoning and efficiency"
      :capabilities (media tool-use cache)


### PR DESCRIPTION
* gptel-gh.el (gptel--gh-models): GitHub Copilot now offers claude-opus-4.8.  Add it with the same capabilities/properties as claude-opus-4.7.

* NEWS (New models and backends): Mention change.