### PR TITLE
Sanitize raw bytes in tool results for JSON

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -980,6 +980,25 @@ and \"apikey\" as USER."
     (string s)
     (otherwise (prin1-to-string s))))
 
+(defun gptel--sanitize-raw-bytes (s)
+  "Replace raw bytes in string S with \"?\" so it is JSON-serializable.
+
+Tool results may contain non-UTF-8 bytes (e.g. from reading a binary
+file), which `json-serialize' rejects.  Returns S unchanged if clean;
+otherwise mutates a single fresh copy in place (O(N), one allocation)."
+  (if (not (memq 'eight-bit (find-charset-string s)))
+      s
+    ;; Allocate exactly once, then mutate in place with `aset'.
+    (let* ((s (if (multibyte-string-p s)
+                  (copy-sequence s)
+                (string-to-multibyte s)))
+           (end (length s))
+           (pos (unencodable-char-position 0 end 'utf-8 nil s)))
+      (while pos
+        (aset s pos ??)
+        (setq pos (unencodable-char-position (1+ pos) end 'utf-8 nil s)))
+      s)))
+
 (defsubst gptel--intern (s)
   "Intern S, if possible."
   (cl-etypecase s
@@ -1925,7 +1944,7 @@ injects the results into the prompt data and transitions the FSM."
          ;; MAYBE(tool-hooks): Use plist-member for valid nil :result?
          (remaining (cl-loop for call in (plist-get info :tool-use)
                              count (not (plist-get call :result)))))
-    (let ((result (gptel--to-string result)))
+    (let ((result (gptel--sanitize-raw-bytes (gptel--to-string result))))
       ;; FIXME(tool-hooks): If a hook has changed the tool that was called
       ;; tool-spec needs to be updated.
       (push (list tool-spec (plist-get tool-call :args) result)


### PR DESCRIPTION
A tool result may contain non-UTF-8 bytes, for example from reading a binary file via a shell command.  Emacs represents these as raw-byte codepoints in the #x3FFF80..#x3FFFFF range, and passing such a string to `json-serialize' signals (wrong-type-argument json-value-p ...), which tears down the request and leaves it unrecoverable.

Add `gptel--sanitize-raw-bytes' to replace raw bytes with "?" and apply it to the tool result string.  Legitimate Unicode is preserved.