### PR TITLE
gptel-request: Allow including only tool call without results

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,6 +64,13 @@
 
 ** New features and UI changes
 
+- The gptel tool's =:include= slot and the global option
+  ~gptel-include-tool-results~ now also accept the symbol =call=: when
+  set, only the call parameters are inserted into the buffer; the result
+  is omitted.  This is useful when the tool results are large or not
+  very human-readable, yet it is important for you or the LLM to track
+  what calls have been made.
+
 - You can now set gptel's system prompt directly via
   ~gptel-system-prompt~.  Previously this required setting an internal
   gptel variable (~gptel--system-message~, now obsolete), or defining a

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1468,15 +1468,21 @@ confirmation only when the corresponding tool spec has a non-nil
 (defcustom gptel-include-tool-results 'auto
   "Whether tool call results should be included in the buffer.
 
-If set to t or nil, results of tool calls are always or never
-included in the LLM response, respectively.
+If set to t, tool calls and results are always included in the LLM
+response.
 
-If set to the symbol auto (the default), a tool call result is
-included only when the corresponding tool spec has a non-nil
-:include slot.  See `gptel-make-tool'."
+If set to nil, tool calls are never shown in the buffer.
+
+If set to the symbol `call', only the tool call parameters are included
+in the buffer; results are omitted.
+
+If set to the symbol auto (the default), this is left up to the tool: a
+tool call is included only when the corresponding tool spec has a
+non-nil :include slot.  See `gptel-make-tool'."
   :type '(choice
           (const :tag "Tool decides" auto)
           (const :tag "Always" t)
+          (const :tag "Call only, no results" call)
           (const :tag "Never" nil)))
 
 (defcustom gptel-tools nil
@@ -1507,7 +1513,10 @@ feed the LLM the results.  You can add tools via
   (async nil :type boolean :documentation "Whether the function runs asynchronously")
   (category nil :type string :documentation "Use to group tools by purpose")
   (confirm nil :type boolean :documentation "Seek confirmation before running tool?")
-  (include t :type boolean :documentation "Include tool results in buffer?"))
+  (include t :type (choice (const :tag "Include call and result" t)
+                           (const :tag "Include call only, no result" call)
+                           (const :tag "Exclude" nil))
+           :documentation "Include tool call in buffer?"))
 
 (defun gptel--preprocess-tool-args (spec)
   "Convert symbol :type values in tool SPEC to strings destructively."
@@ -1636,7 +1645,11 @@ user should be prompted.
 INCLUDE: Whether the tool results should be included as part of
 the LLM output.  This is useful for logging and as context for
 subsequent requests in the same buffer.  This is primarily useful
-in chat buffers.
+in chat buffers.  Possible values:
+
+- t (default): Include both the call parameters and the result.
+- symbol `call': Include only the call parameters, not the result.
+- nil: Exclude the tool call from the buffer entirely.
 
 Here is an example definition:
 

--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -1589,14 +1589,14 @@ This sets the variable `gptel-confirm-tool-calls', which see."
 (transient-define-infix gptel--infix-include-tool-results ()
   "Whether tool call results should be included in the response.
 
-This is a three-way toggle between these behaviors:
+This sets the variable `gptel-include-tool-results', which see.
+The possible values are:
 
-- All tool results are included.
-- No tool results are included.
+- All tool calls and results are included.
+- Only the call parameters are included (result omitted).
+- No tool calls are included.
 - Decided per-tool, according to the value of the tool spec's
-  :include slot.
-
-This sets the variable `gptel-include-tool-results', which see."
+  :include slot."
   :key "-i"
   :description "Include results   "
   :class 'gptel-lisp-variable
@@ -1605,11 +1605,13 @@ This sets the variable `gptel-include-tool-results', which see."
   :display-nil "never"
   :display-map '((nil . "never")
                  (t   . "always")
+                 (call . "calls only")
                  (auto . "auto"))
-  :prompt "Include tool results in LLM response? "
+  :prompt "Include tool calls and results in LLM response? "
   :reader (lambda (prompt &rest _)
             (let* ((choices '(("never"   . nil)
                               ("always" . t)
+                              ("calls only" . call)
                               ("tool decides" . auto)))
                    (pref (completing-read prompt choices nil t)))
               (cdr (assoc pref choices)))))

--- a/gptel.el
+++ b/gptel.el
@@ -2165,7 +2165,7 @@ for tool call results.  INFO contains the state of the request."
          with include-names =
          (mapcar #'gptel-tool-name
                  (cl-remove-if-not #'gptel-tool-include (plist-get info :tools)))
-         if (or (eq gptel-include-tool-results t)
+         if (or (memq gptel-include-tool-results '(t call))
                 (member (gptel-tool-name tool) include-names))
          do (funcall
              (plist-get info :callback)
@@ -2194,14 +2194,20 @@ for tool call results.  INFO contains the state of the request."
                      (string-replace "\n" " "
                                      (truncate-string-to-width
                                       display-call
-                                      (floor (* (window-width) 0.6)) 0 nil " ...)"))))
+                                      (floor (* (window-width) 0.6)) 0 nil " ...)")))
+                    (result-final       ;Check if the results should be excluded
+                     (if (or (eq gptel-include-tool-results 'call)
+                             (and (eq gptel-include-tool-results 'auto)
+                                  (eq (gptel-tool-include tool) 'call)))
+                         "(Cached tool result — available during original generation but not replayed)"
+                       result)))
                (if (derived-mode-p 'org-mode)
                    (concat
                     separator
                     "#+begin_tool "
                     truncated-call
                     (propertize
-                     (org-escape-code-in-string (concat "\n" call "\n\n" result))
+                     (org-escape-code-in-string (concat "\n" call "\n\n" result-final))
                      'gptel `(tool . ,id))
                     "\n#+end_tool\n")
                  ;; TODO(tool) else branch is handling all front-ends as markdown.
@@ -2213,7 +2219,7 @@ for tool call results.  INFO contains the state of the request."
                               'gptel 'ignore 'keymap gptel--markdown-block-map)
                   (propertize
                    ;; TODO(tool) escape markdown in result
-                   (concat "\n" call "\n\n" result)
+                   (concat "\n" call "\n\n" result-final)
                    'gptel `(tool . ,id))
                   ;; TODO(tool) remove properties and strip instead of ignoring
                   (propertize "\n```\n" 'gptel 'ignore


### PR DESCRIPTION
* gptel-request.el (gptel-include-tool-results): (gptel-tool): Add new value as include parameter: `call' to include the call, but not the results.
(gptel-make-tool):
* gptel-transient.el (gptel--infix-include-tool-results): Document all possible values of :include.
* gptel-transient.el (gptel--infix-include-tool-results): Allow selecting the new value from transient menu.
* gptel.el (gptel--display-tool-results): Support the new option, leaving a hint to the LLM that the result is omitted to avoid confusion after the next prompt.
* NEWS (New features and UI changes): Document the new feature.

Some kinds of results, like grep output or web search, are pretty wordy and may not exactly be meaningful in the logs (read - not human-readable).  Yet, it is important to have a trace that such calls have been made, to understand the reasoning process and catch potential issues, like model *not* calling web search and instead relying on internal memory.  The new option allows logging the tool call without inserting the call results.

Assisted-by: DeepSeek + macher.el + custom tools