### PR TITLE
gptel: Normalize tool specs before resolving tool names with presets

### DIFF
--- a/gptel-transient.el
+++ b/gptel-transient.el
@@ -105,7 +105,8 @@ This is intended to be fast but imperfect.  See
           (setq val (cl-loop ; Check against tool names, not tools (faster with sorting)
                      for tool in (ensure-list (gptel--modify-value gptel-tools val))
                      for tool-name = (or (and (stringp tool) tool)
-                                         (ignore-errors (gptel-tool-name tool)))
+                                         (ignore-errors
+                                           (gptel-tool-name (gptel-get-tool tool))))
                      if (not (member tool-name uniq-tool-names))
                      collect tool-name into uniq-tool-names
                      finally return uniq-tool-names))

--- a/gptel.el
+++ b/gptel.el
@@ -2726,14 +2726,12 @@ example) apply the preset buffer-locally."
         (setq val (gptel--modify-value gptel-tools val))
         (let* ((tools
                 (flatten-list
-                 (cl-loop for tool-name in (ensure-list val)
-                          for tool = (cl-etypecase tool-name
-                                       (gptel-tool tool-name)
-                                       (string (ignore-errors
-                                                 (gptel-get-tool tool-name))))
+                 (cl-loop for tool-spec in (ensure-list val)
+                          for tool = (ignore-errors
+                                       (gptel-get-tool tool-spec))
                           do (unless tool
                                (user-error "gptel preset: Cannot find tool %S"
-                                           tool-name))
+                                           tool-spec))
                           collect tool))))
           (funcall setter 'gptel-tools (cl-delete-duplicates tools :test #'eq))))
        ((and (let sym (or (intern-soft
@@ -2843,7 +2841,8 @@ See also `gptel--preset-mismatch-p'."
                 for tool in preset-tools
                 for tool-name =
                 (or (and (stringp tool) tool)
-                    (ignore-errors (gptel-tool-name tool)))
+                    (ignore-errors (gptel-tool-name
+                                    (gptel-get-tool tool))))
                 if (not (member tool-name uniq-tool-names))
                 collect tool-name into uniq-tool-names
                 finally return


### PR DESCRIPTION
This makes preset parsing accept tool specs in a more uniform way, whether they are already tool objects, strings, or in the form of `(category name)`. Fixes #1471.

Tool handling in transient and preset mismatch computation now consistently resolves tool specifications through `gptel-get-tool` before extracting names.

* gptel.el: (`gptel--apply-preset`): Resolve each tool spec through `gptel-get-tool` when applying presets. (`gptel--preset-mismatch-value`):

* gptel-transient.el: (`gptel--preset-mismatch-p`): Resolve tool specs with `gptel-get-tool` before reading tool names.