### PR TITLE
gptel-openai-oauth: Don't wait for RET to open authorization URLs

### DIFF
--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -112,10 +112,9 @@ when appropriate for the current session."
            (format "(One-time code %s copied) Visit %s in your local browser, \
 enter the code and authorize.  Press ENTER after authorizing: "
                    user-code verification-uri)))
-      (read-from-minibuffer
-       (format "(One-time code %s copied) Press ENTER to open the authorization page. \
+      (message "One-time code %s copied. \
 If your browser does not open automatically, browse to %s: "
-               user-code verification-uri))
+               user-code verification-uri)
       (browse-url verification-uri)
       (read-from-minibuffer
        (format "(One-time code %s copied) Press ENTER after authorizing: "

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -250,13 +250,10 @@ charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
                    :service gptel--openai-oauth-redirect-port
                    :filter #'filter
                    :noquery t))
-            (message "OpenAI OAuth authorization URL: %s" authorization-url)
             (ignore-errors (gui-set-selection 'CLIPBOARD authorization-url))
-            (read-from-minibuffer
-             (format "OpenAI OAuth URL copied to clipboard.  \
-Press ENTER to open the authorization page.  \
+            (message "OpenAI OAuth URL copied to clipboard.  \
 If your browser does not open automatically, browse to %s: "
-                     authorization-url))
+                    authorization-url)
             (browse-url authorization-url)
             (while (and (not code) (not error) (< (float-time) deadline))
               (accept-process-output nil 1))


### PR DESCRIPTION
The current OAuth flow asks the user to press enter before opening the browser which is unnecessary.