### PR TITLE
FSM stuck at TOOL state when model response contains 2+ tool calls (Ollama backend)

### DIFF
--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -67,7 +67,8 @@ back to the LLM)."
                 (tool-calls (map-nested-elt content '(:message :tool_calls))))
             (when (and response (not (eq response :null)))
               (push response content-strs))
-            (when (and tool-calls (not (eq tool-calls :null)))
+            (when (and tool-calls (not (eq tool-calls :null))
+                       (not (plist-get info :tool-calls-captured)))
               (gptel--inject-prompt
                (plist-get info :backend) (plist-get info :data)
                `(:role "assistant" :content :null :tool_calls ,(vconcat tool-calls)))
@@ -80,7 +81,8 @@ back to the LLM)."
                collect call-spec into tool-use
                finally
                (plist-put info :tool-use
-                          (append (plist-get info :tool-use) tool-use))))
+                          (append (plist-get info :tool-use) tool-use))
+               (plist-put info :tool-calls-captured t)))
             (if (and reasoning (not (eq reasoning :null)))
                 (plist-put info :reasoning
                            (concat (plist-get info :reasoning) reasoning))

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1902,7 +1902,9 @@ MACHINE is an instance of `gptel-fsm'"
   ;; a second network request: gptel tests for the presence of these flags to
   ;; handle state transitions.  (NOTE: Don't add :uuid to this.)
   (let ((info (gptel-fsm-info fsm)))
-    (dolist (key '(:tool-result :tool-use :error :http-status :reasoning :tokens))
+    (dolist (key '(:tool-result :tool-use :tool-calls-captured :error :http-status :reasoning :tokens
+                   :partial_json :reasoning-block :reasoning-chunks
+                   :signature :partial_text :partial_reasoning))
       (when (plist-get info key)
         (plist-put info key nil))))
   (funcall
@@ -1936,7 +1938,9 @@ injects the results into the prompt data and transitions the FSM."
       ;; FIXME: Make the implicit addition to :tool-use explicit
       (plist-put tool-call :result result)) ;for the LLM
     ;; All tools have run
-    (when (<= (cl-decf remaining) 0) (gptel--fsm-transition fsm))))
+    (when (and (plist-get info :tool-use)        ; Guard against nil :tool-use
+               (<= (cl-decf remaining) 0))
+      (gptel--fsm-transition fsm))))
 
 (defun gptel--handle-tool-use (fsm)
   "Run tool calls captured in FSM, and advance the state machine with the results."

--- a/gptel.el
+++ b/gptel.el
@@ -532,20 +532,33 @@ Otherwise move ARG times, defaulting to 1."
   (interactive)
   (save-excursion
     (forward-line 0)
-    (let (start end (parity 0))
+    (let (start end (parity 0)
+           ;; Check if this is a gptel structural fence (reasoning/tool block).
+          ;; If so, only count fences with the `gptel' text property when
+          ;; matching parity, so that model output containing ``` inside
+          ;; the block doesn't break the fold.
+          (gptel-block (get-char-property (point) 'gptel)))
       (cond            ;Find start and end of block, with possible nested blocks
        ((looking-at-p "^``` *\n")       ;end of block, find corresponding start
         (setq parity -1 end (line-end-position))
         (while (and (not (= parity 0)) (not (bobp)) (forward-line -1))
-          (cond ((looking-at-p "^``` *\n") (cl-decf parity))
-                ((looking-at-p "^``` ?[a-z]") (cl-incf parity))))
+          (cond ((and (looking-at-p "^``` *\n")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-decf parity))
+                ((and (looking-at-p "^``` ?[a-z]")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-incf parity))))
         (when (= parity 0) (setq start (point))))
 
        ((looking-at-p "^``` ?[a-z]") ;beginning of block, find corresponding end
         (setq parity 1 start (point))
         (while (and (not (= parity 0)) (not (eobp)) (forward-line 1))
-          (cond ((looking-at-p "^``` *\n") (cl-decf parity))
-                ((looking-at-p "^``` ?[a-z]") (cl-incf parity))))
+          (cond ((and (looking-at-p "^``` *\n")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-decf parity))
+                ((and (looking-at-p "^``` ?[a-z]")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-incf parity))))
         (when (= parity 0) (setq end (line-end-position)))))
       (when (and start end)
         (goto-char start)


### PR DESCRIPTION
# DISCLAIMER
This PR contains AI generated code.

## Environment

- gptel 0.9.9.5 (ELPA: 20260628.758)
- Backend: Ollama (local, streaming)
- Emacs 29+ in terminal mode (no markdown-mode, using text-mode)
- Models: various Ollama models (glm-5.2:cloud, gpt-oss:120b, etc.)

## Problem

When a model response contains 2 or more tool calls in a single response, the FSM gets stuck at the TOOL state after executing all tool calls. The state never transitions to TRET, so the tool results are never injected back into the prompt and the request hangs indefinitely.

With a single tool call per response, everything works correctly.

## Root Cause Analysis

We traced the issue through the FSM transition chain:

### FSM States (gptel-send--transitions)

```
TYPE -> TPRE -> TOOL -> TRET -> WAIT (loop back for tool results)
```

### What happens with 2+ tool calls

1. Model response arrives with 2 tool calls
2. Both tool calls are captured in `:tool-use` (after fixing an Ollama streaming dedup issue -- see below)
3. FSM transitions: TYPE -> TPRE -> TOOL
4. At TOOL, `gptel--handle-tool-use` runs, executes both tools synchronously
5. Each tool call triggers `gptel--process-tool-call`, which decrements `remaining`
6. On the second call, `remaining` should reach 0, triggering `(gptel--fsm-transition fsm)` to move TOOL -> TRET
7. **But the transition doesn't fire** (or fires but doesn't reach TRET handlers)

### Key functions involved

**`gptel--process-tool-call`** (gptel-request.el):
```elisp
(defun gptel--process-tool-call (fsm tool-spec tool-call result)
  (let* ((info (gptel-fsm-info fsm))
         (tool-result-alist (plist-get info :tool-result))
         (remaining (cl-loop for call in (plist-get info :tool-use)
                             count (not (plist-get call :result)))))
    ;; ... store result ...
    (when (<= (cl-decf remaining) 0)
      (gptel--fsm-transition fsm))))
```

`remaining` is computed by counting tool calls without `:result`. After the first tool call gets its result, `remaining` should be 1. After the second, it should be 0, triggering the transition.

**`gptel--handle-tool-use`** (gptel-request.el):
```elisp
(defun gptel--handle-tool-use (fsm)
  (when-let* ((info (gptel-fsm-info fsm))
              (backend (plist-get info :backend))
              (tool-use (cl-remove-if (lambda (tc) (plist-get tc :result))
                                      (plist-get info :tool-use))))
    ;; ... execute tools ...
    ))
```

This runs at TOOL state. It executes all pending tool calls. For synchronous tools, `gptel--process-tool-call` is called inline within the `mapc`.

### Suspected causes

1. **`remaining` count is wrong**: If `:result` is set on a tool call before `remaining` is computed (e.g., by a pre-tool-call hook or by the first tool's `process-tool-call` modifying the shared plist), the count could be off.

2. **Transition fires but goes to wrong state**: `gptel--fsm-transition` without an explicit `new-state` calls `gptel--fsm-next`, which looks up the transition table. For TOOL state, the only transition is `(t . TRET)`. This should always go to TRET. But if the FSM state was changed by a nested call, it might not.

3. **Nested `gptel--handle-wait` resets**: If `gptel--handle-wait` is called during tool processing (e.g., by an async tool callback), it resets `:tool-use` to nil. We added a guard for this:
   ```elisp
   (when (and (plist-get info :tool-use)
              (<= (cl-decf remaining) 0))
     (gptel--fsm-transition fsm))
   ```
   But this guard might itself be the problem -- if `:tool-use` is nil at the moment of the check, the transition never fires even though tools were executed.

4. **Ollama streaming parser duplicate accumulation** (secondary issue, partially fixed): The Ollama streaming parser appends tool calls to `:tool-use` for every chunk containing `tool_calls`. When tool calls arrive across multiple streaming chunks, duplicates accumulate. We added a `:tool-calls-captured` flag to prevent this:
   ```elisp
   (when (and tool-calls (not (eq tool-calls :null))
              (not (plist-get info :tool-calls-captured)))
     ;; ... accumulate tool calls ...
     (plist-put info :tool-calls-captured t))
   ```
   And added `:tool-calls-captured` to the `gptel--handle-wait` reset list. This fixed tool call registration (both calls now appear in `:tool-use`), but the FSM still doesn't transition.

## Local patches applied (for reference)

We have the following patches in our local copies (both in a writable fork and in the ELPA installation):

### gptel-request.el

1. **handle-wait reset list expansion** -- resets streaming parser state across cycles:
```diff
-    (dolist (key '(:tool-result :tool-use :error :http-status :reasoning :tokens))
+    (dolist (key '(:tool-result :tool-use :tool-calls-captured :error :http-status :reasoning :tokens
+                   :partial_json :reasoning-block :reasoning-chunks
+                   :signature :partial_text :partial_reasoning))
```

2. **process-tool-call nil guard** -- prevents spurious transition when :tool-use is nil:
```diff
-    (when (<= (cl-decf remaining) 0) (gptel--fsm-transition fsm))))
+    (when (and (plist-get info :tool-use)
+               (<= (cl-decf remaining) 0))
+      (gptel--fsm-transition fsm))));
```

### gptel-ollama.el

3. **Tool call dedup flag** -- prevents duplicate accumulation in streaming:
```diff
-            (when (and tool-calls (not (eq tool-calls :null)))
+            (when (and tool-calls (not (eq tool-calls :null))
+                       (not (plist-get info :tool-calls-captured)))
```
```diff
-               (plist-put info :tool-use
-                          (append (plist-get info :tool-use) tool-use))))
+               (plist-put info :tool-use
+                          (append (plist-get info :tool-use) tool-use))
+               (plist-put info :tool-calls-captured t)))
```

### gptel.el

4. **Markdown cycle-block folding fix** -- prevents model-output backticks from breaking structural fence folding:
```diff
     (let (start end (parity 0)
+           (gptel-block (get-char-property (point) 'gptel)))
       (cond
        ((looking-at-p "^``` *\n")
         ...
-          (cond ((looking-at-p "^``` *\n") (cl-decf parity))
-                ((looking-at-p "^``` ?[a-z]") (cl-incf parity))))
+          (cond ((and (looking-at-p "^``` *\n")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-decf parity))
+                ((and (looking-at-p "^``` ?[a-z]")
+                      (or (not gptel-block) (get-char-property (point) 'gptel)))
+                 (cl-incf parity))))
```

## What we haven't tried

- Adding `message` logging inside `gptel--process-tool-call` to trace `remaining` values
- Checking if `gptel--fsm-transition` is called but `gptel--fsm-next` returns something unexpected
- Testing with non-streaming mode (we use streaming exclusively)
- Testing with non-Ollama backends

## Workaround

Enforce one tool call per response at the prompt level. This avoids the code path entirely and is actually better for autonomous agent use cases (each tool result is visible before the next action).

## Related

- The `gptel--handle-wait` reset list not including streaming parser state (`:partial_json`, `:reasoning-block`, etc.) may cause separate issues on follow-up requests after tool use. We believe this is a real bug regardless of the stuck-at-TOOL issue.