### PR TITLE
gptel-openai-extras: Add grok 4.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -63,7 +63,8 @@
 - OpenAI backend: Add support for =gpt-5.6-sol=, =gpt-5.6-terra= and
   =gpt-5.6-luna=.
 
-- xAI backend: Add support for =grok-4.3= and =grok-build-0.1=.
+- xAI backend: Add support for =grok-4.3=, =grok-build-0.1= and
+  =grok-4.5=.
 
 ** New features and UI changes
 

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -362,8 +362,16 @@ For the meanings of the keyword arguments, see `gptel-make-openai'."
           (protocol "https")
           (endpoint "/v1/chat/completions")
           (models
-           '((grok-4.3
-              :description "Our most advanced flagship model, leading the industry in non-hallucination rate, agentic tool calling, and instruction following capabilities."
+           '((grok-4.5
+              :description "Most advanced flagship model, leading in agentic tool calling and instruction following capabilities."
+              :capabilities (tool-use json media reasoning)
+              :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+              :context-window 500
+              :input-cost 2
+              :output-cost 6)
+
+             (grok-4.3
+              :description "Advanced flagship model, leading in agentic tool calling and instruction following capabilities."
               :capabilities (tool-use json media reasoning)
               :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
               :context-window 1000


### PR DESCRIPTION
Although the ~~xAI~~ SpaceXAI website only lists `grok-4.5` these days, I still get different responses if I call the older model IDs, so I left them in for now.