### PR TITLE
#1480, Groq: llama3-70b-8192 and llama-3.1-8b-instant deprecated

### DIFF
--- a/README.org
+++ b/README.org
@@ -760,12 +760,11 @@ Register a backend with
   :stream t
   :key "your-api-key"                   ;can be a function that returns the key
   :models '(gemma-7b-it
-            llama-3.1-8b-instant
-            llama3-70b-8192
             llama3-8b-8192
             mixtral-8x7b-32768
-            qwen/qwen3.6-27b
-            openai/gpt-oss-120b))
+            openai/gpt-oss-20b
+            openai/gpt-oss-120b
+            qwen/qwen3.6-27b))
 #+end_src
 
 You can pick this backend from the menu when using gptel (see [[#usage][Usage]]).  Note that Groq is fast enough that you could set =:stream nil= and still get near-instant responses.
@@ -784,12 +783,11 @@ The above code makes the backend available to select.  If you want it to be the 
         :stream t
         :key "your-api-key"
         :models '(gemma-7b-it
-                  llama-3.1-8b-instant
-                  llama3-70b-8192
                   llama3-8b-8192
                   mixtral-8x7b-32768
-                  qwen/qwen3.6-27b
-                  openai/gpt-oss-120b)))
+                  openai/gpt-oss-20b
+                  openai/gpt-oss-120b
+                  qwen/qwen3.6-27b)))
 #+end_src
 
 #+html: </details>


### PR DESCRIPTION
Deprecated models and recommended replacements according to

https://console.groq.com/docs/deprecations

llama3-70b-8192 ==> llama3-8b-8192

llama-3.1-8b-instant ==> openai/gpt-oss-20b
