### PR TITLE
Remove soon to be deprecated deepseek-chat and deepseek-reasoner model.

### DIFF
--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -312,17 +312,7 @@ The Deepseek API requires strictly alternating roles (user/assistant) in message
           (host "api.deepseek.com")
           (protocol "https")
           (endpoint "/v1/chat/completions")
-          (models '((deepseek-reasoner
-                     :capabilities (tool reasoning)
-                     :context-window 128
-                     :input-cost 0.14
-                     :output-cost 0.28)
-                    (deepseek-chat
-                     :capabilities (tool)
-                     :context-window 128
-                     :input-cost 0.14
-                     :output-cost 0.28)
-		    (deepseek-v4-flash
+          (models '((deepseek-v4-flash
                      :capabilities (tool reasoning)
                      :context-window 1000
                      :input-cost 0.14


### PR DESCRIPTION
<img width="739" height="464" alt="image" src="https://github.com/user-attachments/assets/692e5583-4e5b-4026-af10-d7a6ef548ca2" />

According to deepseek's api doc, these two models will be deprecated soon.