### PR TITLE
Remove deprecated or no longer available Copilot models

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@
   removed from the default list of Deepseek models.  These models are
   either deprecated or no longer available.
 
+- The models =gptel-5-1=, =gpt-5.1-codex=, =gpt-5.1-codex-max=,
+  =gpt-5.1-codex-mini=, =gpt-5.2=, =gpt-5.2-codex=, =claude-sonnet-4=,
+  =gemini-3-pro-preview= and =grok-code-fast-1= have been removed from
+  the default list of Copilot models. These models are either deprecated
+  or no longer available.
+
 - The models =claude-3-7-sonnet-20250219=, =claude-3-5-sonnet-20241022=,
   =claude-3-5-sonnet-20240620=, =claude-3-5-haiku-20241022=,
   =claude-3-opus-20240229= and =claude-3-haiku-20240307= have been

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -54,54 +54,6 @@
      :input-cost 0
      :output-cost 0
      :cutoff-date "2024-06")
-    (gpt-5.1
-     :description "The best model for coding and agentic tasks"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2024-09")
-    (gpt-5.1-codex
-     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2024-09")
-    (gpt-5.1-codex-max
-     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2024-09")
-    (gpt-5.1-codex-mini
-     :description "Flagship model for coding, reasoning, and agentic tasks across domains"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2024-09")
-    (gpt-5.2
-     :description "The best model for coding and agentic tasks"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-08")
-    (gpt-5.2-codex
-     :description "The best model for coding and agentic tasks"
-     :capabilities (media tool-use json url responses-api)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
-     :context-window 272
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-08")
     (gpt-5.3-codex
      :description "The most capable agentic coding model to date"
      :capabilities (media tool-use json url responses-api)
@@ -182,14 +134,6 @@
      :input-cost 10
      :output-cost 50
      :cutoff-date "2026-01")
-    (claude-sonnet-4
-     :description "High-performance model with exceptional reasoning and efficiency"
-     :capabilities (media tool-use cache)
-     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp" "application/pdf")
-     :context-window 128
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-03")
     (claude-sonnet-4.5
      :description "High-performance model with exceptional reasoning and efficiency"
      :capabilities (media tool-use cache)
@@ -234,17 +178,6 @@
      :input-cost 0.33
      :output-cost 0.33
      :cutoff-date "2025-01")
-    (gemini-3-pro-preview
-     :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
-     :capabilities (tool-use json media audio video)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                  "application/pdf" "text/plain" "text/csv" "text/html"
-                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
-                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
-     :context-window 109
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-01")
     (gemini-3.1-pro-preview
      :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
      :capabilities (tool-use json media audio video)
@@ -266,14 +199,7 @@
      :context-window 109
      :input-cost 1
      :output-cost 1
-     :cutoff-date "2025-01")
-    (grok-code-fast-1
-     :description "Fast reasoning model for agentic coding"
-     :capabilities '(tool-use json reasoning)
-     :context-window 109
-     :input-cost 0.25
-     :output-cost 1.5
-     :cutoff-date "2025-08")))
+     :cutoff-date "2025-01")))
 
 (cl-defstruct (gptel--gh (:include gptel-openai)
                          (:copier nil)


### PR DESCRIPTION
Some Copilot models are no longer available. I realized when my default model, gpt-5.2, stopped working, but after checking I realized a lot more don't work. I checked and some depend on the specific subscription plan ([source](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan)), but some like gpt-5.2 don't. The model retirement history can be found [here](https://docs.github.com/en/copilot/reference/ai-models/supported-models#model-retirement-history), although it's not completely reliable (for example gpt-4.1 should have been retired according to that, but it still works for me).

I checked the commit history and I saw the the list of available models is regularly kept up to date for other providers, so I'm submitting this PR, using as reference https://github.com/karthink/gptel/commit/5c82ff85be0beed57a923935e18b9c4d1a8d0858.

There are also some models listed in the documentation as available that are not supported yet by gptel. I will try those available in my subscription and add them in a different PR