### PR TITLE
Update News for remove soon to be deprecated deepseek-chat and deepseek-reasoner model.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@
 
 ** Breaking changes
 
+- The models =deepseek-chat= and =deepseek-reasoner= have been
+  removed from the default list of Deepseek models.  These models are
+  either deprecated or no longer available.
+
 - The models =claude-3-7-sonnet-20250219=, =claude-3-5-sonnet-20241022=,
   =claude-3-5-sonnet-20240620=, =claude-3-5-haiku-20241022=,
   =claude-3-opus-20240229= and =claude-3-haiku-20240307= have been


### PR DESCRIPTION
<img width="1477" height="928" alt="image" src="https://github.com/user-attachments/assets/bf1fff30-6cee-4002-becf-b3a66bb788e1" />

According to deepseek's api doc, these two models will be deprecated soon.