### PR TITLE
Remove soon to be deprecated deepseek-chat and deepseek-reasoner model.

### DIFF
--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -332,17 +332,7 @@ This method works by wrapping the main implementation, passing PROMPTS."
           (host "api.deepseek.com")
           (protocol "https")
           (endpoint "/v1/chat/completions")
-          (models '((deepseek-reasoner
-                     :capabilities (tool reasoning)
-                     :context-window 128
-                     :input-cost 0.14
-                     :output-cost 0.28)
-                    (deepseek-chat
-                     :capabilities (tool)
-                     :context-window 128
-                     :input-cost 0.14
-                     :output-cost 0.28)
-		    (deepseek-v4-flash
+          (models '((deepseek-v4-flash
                      :capabilities (tool reasoning)
                      :context-window 1000
                      :input-cost 0.14


### PR DESCRIPTION
<img width="1477" height="928" alt="image" src="https://github.com/user-attachments/assets/13bc0dfc-fdb9-453c-8ded-7e0790e34220" />

According to deepseek's api doc, these two models will be deprecated soon.