### PR TITLE
gptel-gemini, gptel-gh: Add new gemini-3.6-flash, gemini-3.5-flash-lite models

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,10 +64,12 @@
 - Anthropic backend: Add support for =claude-sonnet-5=,
   =claude-opus-4-8= and =claude-fable-5=.
 
-- GitHub Copilot backend: Add support for =gemini-3.5-flash=,
+- GitHub Copilot backend: Add support for =gemini-3.6-flash=,
+  =gemini-3.5-flash=,
   =claude-opus-4.8=, =claude-sonnet-5= and =claude-fable-5=.
 
-- Gemini backend: Add support for =gemini-3.5-flash=,
+- Gemini backend: Add support for =gemini-3.6-flash=,
+  =gemini-3.5-flash=, =gemini-3.5-flash-lite=,
   =gemini-3.1-flash-lite= and deprecate the preview version.
 
 - OpenAI backend: Add support for =gpt-5.6-sol=, =gpt-5.6-terra= and

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -466,6 +466,17 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 0.10
      :output-cost 0.40
      :cutoff-date "2025-01")
+    (gemini-3.6-flash
+     :description "Most intelligent Gemini model built for speed, combining frontier intelligence with superior search and grounding"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 1048
+     :input-cost 1.50
+     :output-cost 7.50
+     :cutoff-date "2026-07")
     (gemini-3.5-flash
      :description "Most intelligent Gemini model for sustained frontier performance in agentic and coding tasks"
      :capabilities (tool-use json media audio video)
@@ -477,6 +488,17 @@ Media files, if present, are placed in `gptel-context'."
      :input-cost 1.50
      :output-cost 9.00
      :cutoff-date "2025-01")
+    (gemini-3.5-flash-lite
+     :description "Most cost-efficient multimodal Gemini model, optimized for high-volume agentic tasks and simple data processing"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 1048
+     :input-cost 0.30
+     :output-cost 2.50
+     :cutoff-date "2026-07")
     (gemini-3.1-pro-preview
      :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
      :capabilities (tool-use json media audio video)

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -189,6 +189,17 @@
      :input-cost 1
      :output-cost 1
      :cutoff-date "2025-01")
+    (gemini-3.6-flash
+     :description "Most intelligent Gemini model built for speed, combining frontier intelligence with superior search and grounding"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 109
+     :input-cost 1
+     :output-cost 1
+     :cutoff-date "2026-07")
     (gemini-3.5-flash
      :description "Most intelligent Gemini model for sustained frontier performance in agentic and coding tasks"
      :capabilities (tool-use json media audio video)


### PR DESCRIPTION
And update the NEWS file.

Refs: 
- Announcements: 
  - https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/
  - https://github.blog/changelog/2026-07-21-gemini-3-6-flash-is-now-available-in-github-copilot/
- https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
- https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite