### PR TITLE
Fix for #1491

### DIFF
--- a/gptel-rewrite.el
+++ b/gptel-rewrite.el
@@ -218,7 +218,7 @@ which see."
             " " 'display
             (if (and (fboundp 'string-pixel-width)
                      (display-graphic-p))
-                `(space :align-to (- right (,(string-pixel-width hint-str))))
+                `(space :align-to (- right ,(string-pixel-width hint-str)))
               `(space :align-to (- right ,(+ 1 (string-width hint-str))))))
            (propertize hint-str 'face '(warning default)))) ;status element 3
     (overlay-put ov 'before-string (apply #'concat (overlay-get ov 'status)))))

--- a/gptel.el
+++ b/gptel.el
@@ -938,7 +938,7 @@ Search between BEG and END."
           " " 'display
           (if (and (fboundp 'string-pixel-width)
                    (display-graphic-p))
-              `(space :align-to (- right (,(string-pixel-width rhs))))
+              `(space :align-to (- right ,(string-pixel-width rhs)))
             `(space :align-to (- right ,(+ 5 (string-width rhs))))))
          rhs))))
   "Information segment for the header-line in `gptel-mode'.")


### PR DESCRIPTION
As described in #1491, `gptel-rewrite` causes segfaults in Emacs
v31.0.90.

As it turns out this is due to an illegal `:align-to` spec when
propertising the `rewrite`.  As per `info:elisp#Specified Space`,
we're allowed to have pixel specifications for `:align-to`.
`info:elisp#Pixel Specification` indicates that a pixel spec with an
OP should have the form `(OP EXPR...)`.

The fix here is changing `(OP EXPR (EXPR))` (incorrect) to `(OP EXPR EXPR)`.  
There were two instances I found in the `gptel` source code,
in `gptel-rewrite` (the impetus for my exploration) as well as in the
header-line code for `gptel-mode` so I fixed them.