### PR TITLE
Allow tool calls to be rejected, yet continuing the conversation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -154,6 +154,16 @@
   starting MCP servers.  Previously all tools provided by an MCP server
   would be added automatically.  See ~gptel-mcp-connect~ for details.
 
+- When tool calls require confirmation, you can now choose to reject
+  them and continue the conversation instead of stopping it entirely.
+  Choosing "Reject (continue)" feeds a rejection message back to the
+  LLM for each tool call, allowing the model to adapt and proceed
+  without running the tools.
+
+  This option is available in the tool call dispatch overlay (~C-c C-r~),
+  the minibuffer confirmation prompt (=r=), and the tool call inspection
+  buffer (~C-c C-r~ or the "Reject" button in the header line).
+
 ** Notable bug fixes
 
 - Improved error messages: Curl request failures now include more

--- a/NEWS
+++ b/NEWS
@@ -118,6 +118,16 @@
   outputs simultaenously in a request.  Previously the two were
   incompatible.
 
+- When tool calls require confirmation, you can now choose to reject
+  them and continue the conversation instead of stopping it entirely.
+  Choosing "Reject (continue)" feeds a rejection message back to the
+  LLM for each tool call, allowing the model to adapt and proceed
+  without running the tools.
+
+  This option is available in the tool call dispatch overlay (~C-c C-r~),
+  the minibuffer confirmation prompt (=r=), and the tool call inspection
+  buffer (~C-c C-r~ or the "Reject" button in the header line).
+
 ** Notable bug fixes
 
 - Improved error messages: Curl request failures now include more

--- a/gptel.el
+++ b/gptel.el
@@ -2034,6 +2034,7 @@ Note: This tool call preview API is currently experimental.")
   "<mouse-1>" #'gptel--dispatch-tool-calls
   "C-c C-c" #'gptel--accept-tool-calls
   "C-c C-k" #'gptel--reject-tool-calls
+  "C-c C-r" #'gptel--reject-tool-calls-and-continue
   "C-c C-i" #'gptel--inspect-tool-calls)
 
 (defun gptel--display-tool-calls (tool-calls info &optional use-minibuffer)
@@ -2068,20 +2069,23 @@ USE-MINIBUFFER is non-nil)."
                                  backend-name len (if (> len 1) "calls" "call")
                                  tool-call-names))
                  (choices '((?y "Run tools") (?n "Cancel (resumable)")
-                            (?i "Inspect or edit")))
+                            (?r "Reject (continue)") (?i "Inspect or edit")))
                  (choice (read-multiple-choice prompt choices)))
             (pcase (car choice)
               (?y (gptel--accept-tool-calls tool-calls))
               (?n (gptel--reject-tool-calls))
+              (?r (gptel--reject-tool-calls-and-continue tool-calls))
               (?i (gptel--inspect-tool-calls tool-calls info))))
         ;; Prompt for confirmation from the response buffer
         (let* ((backend-name (gptel-backend-name (plist-get info :backend)))
                (actions-string
                 (concat (propertize "Run tools: " 'face 'font-lock-string-face)
                         (propertize "C-c C-c" 'face 'help-key-binding)
-                        (propertize ", Cancel request: " 'face 'font-lock-string-face)
+                        (propertize ", Cancel: " 'face 'font-lock-string-face)
                         (propertize "C-c C-k" 'face 'help-key-binding)
-                        (propertize ", Inspect or Edit: " 'face 'font-lock-string-face)
+                        (propertize ", Reject: " 'face 'font-lock-string-face)
+                        (propertize "C-c C-r" 'face 'help-key-binding)
+                        (propertize ", Inspect: " 'face 'font-lock-string-face)
                         (propertize "C-c C-i" 'face 'help-key-binding)))
                (confirm-strings)
                ;; FIXME(tool) use a wrapper instead of a manual text-property search,
@@ -2335,16 +2339,46 @@ OV is the tool call dispatch overlay."
                          (overlay-end prompt-ov)))))
     (delete-overlay ov)))
 
+(defun gptel--reject-tool-calls-and-continue (&optional tool-calls ov)
+  "Reject pending TOOL-CALLS and continue the request chain.
+
+Feed a rejection message to the LLM for each tool call so the
+conversation can proceed.  OV is the tool call dispatch overlay."
+  (interactive (pcase-let ((`(,resp . ,o) (get-char-property-and-overlay
+                                           (point) 'gptel-tool)))
+                 (list resp o)))
+  (gptel--update-status " Tools rejected" 'error)
+  (when tool-calls
+    (let* ((default "Tool call rejected by user.")
+           (msg (read-string
+                 (format-prompt "Rejection message: " default)
+                 nil nil default)))
+      (cl-loop for (_tool-spec _arg-plist process-tool-result) in tool-calls
+               do (funcall process-tool-result msg))))
+  (when (and (overlayp ov) (overlay-buffer ov))
+    (with-current-buffer (overlay-buffer ov)
+      (when-let* ((preview-handles (overlay-get ov 'previews)))
+        (dolist (func-to-handle preview-handles)
+          (when (car func-to-handle) (apply func-to-handle))))
+      (dolist (prompt-ov (overlay-get ov 'prompt))
+        (when-let* (((overlay-buffer prompt-ov))
+                    (inhibit-read-only t))
+          (delete-region (overlay-start prompt-ov)
+                         (overlay-end prompt-ov)))))
+    (delete-overlay ov)))
+
 (defun gptel--dispatch-tool-calls (choice)
   "Dispatch on tool-calls with CHOICE."
   (interactive
    (list
     (let ((choices '((?y "yes") (?n "do nothing")
-                     (?k "cancel request") (?i "inspect call(s)"))))
+                     (?k "cancel request") (?r "reject (continue)")
+                     (?i "inspect call(s)"))))
       (read-multiple-choice "Run tool calls? " choices))))
   (pcase (car choice)
     (?y (call-interactively #'gptel--accept-tool-calls))
     (?k (call-interactively #'gptel--reject-tool-calls))
+    (?r (call-interactively #'gptel--reject-tool-calls-and-continue))
     (?i (call-interactively #'gptel--inspect-tool-calls))))
 
 ;;;; Tool call inspection UI
@@ -2352,6 +2386,7 @@ OV is the tool call dispatch overlay."
   :doc "Actions in the gptel tool inspection buffer."
   "C-c C-c" #'gptel--inspect-accept-tool-calls
   "C-c C-k" #'gptel--inspect-reject-tool-calls
+  "C-c C-r" #'gptel--inspect-reject-tool-calls-and-continue
   "C-c C-i" #'gptel--inspect-quit-tool-calls)
 
 (defun gptel--inspect-accept-tool-calls (&optional _)
@@ -2414,8 +2449,18 @@ This is a bug, please report it!"))))
   "Cancel tool-calls and return to query buffer."
   (interactive)
   (apply #'gptel--reject-tool-calls
-   (thread-first (gptel-fsm-info gptel--fsm-last)
-                 (plist-get :tool-display)))
+         (thread-first (gptel-fsm-info gptel--fsm-last)
+                       (plist-get :tool-display)))
+  (quit-window t))
+
+(defun gptel--inspect-reject-tool-calls-and-continue (&optional _)
+  "Reject tool-calls from the inspection buffer and continue the chain.
+
+Feed a rejection message to the LLM for each tool call and clean up."
+  (interactive)
+  (apply #'gptel--reject-tool-calls-and-continue
+         (thread-first (gptel-fsm-info gptel--fsm-last)
+                       (plist-get :tool-display)))
   (quit-window t))
 
 (defun gptel--inspect-quit-tool-calls (&optional _)
@@ -2499,6 +2544,8 @@ query buffer."
               " \\[gptel--inspect-accept-tool-calls], "
               (buttonize "Cancel" #'gptel--inspect-reject-tool-calls)
               " \\[gptel--inspect-reject-tool-calls], "
+              (buttonize "Reject" #'gptel--inspect-reject-tool-calls-and-continue)
+              " \\[gptel--inspect-reject-tool-calls-and-continue], "
               (buttonize "Return" #'gptel--inspect-quit-tool-calls)
               " \\[gptel--inspect-quit-tool-calls], "
               (buttonize "Edit" (lambda (_) (read-only-mode 'toggle)))

--- a/gptel.el
+++ b/gptel.el
@@ -2031,6 +2031,7 @@ Note: This tool call preview API is currently experimental.")
   "<mouse-1>" #'gptel--dispatch-tool-calls
   "C-c C-c" #'gptel--accept-tool-calls
   "C-c C-k" #'gptel--reject-tool-calls
+  "C-c C-r" #'gptel--reject-tool-calls-and-continue
   "C-c C-i" #'gptel--inspect-tool-calls)
 
 (defun gptel--display-tool-calls (tool-calls info &optional use-minibuffer)
@@ -2065,20 +2066,23 @@ USE-MINIBUFFER is non-nil)."
                                  backend-name len (if (> len 1) "calls" "call")
                                  tool-call-names))
                  (choices '((?y "Run tools") (?n "Cancel (resumable)")
-                            (?i "Inspect or edit")))
+                            (?r "Reject (continue)") (?i "Inspect or edit")))
                  (choice (read-multiple-choice prompt choices)))
             (pcase (car choice)
               (?y (gptel--accept-tool-calls tool-calls))
               (?n (gptel--reject-tool-calls))
+              (?r (gptel--reject-tool-calls-and-continue tool-calls))
               (?i (gptel--inspect-tool-calls tool-calls info))))
         ;; Prompt for confirmation from the response buffer
         (let* ((backend-name (gptel-backend-name (plist-get info :backend)))
                (actions-string
                 (concat (propertize "Run tools: " 'face 'font-lock-string-face)
                         (propertize "C-c C-c" 'face 'help-key-binding)
-                        (propertize ", Cancel request: " 'face 'font-lock-string-face)
+                        (propertize ", Cancel: " 'face 'font-lock-string-face)
                         (propertize "C-c C-k" 'face 'help-key-binding)
-                        (propertize ", Inspect or Edit: " 'face 'font-lock-string-face)
+                        (propertize ", Reject: " 'face 'font-lock-string-face)
+                        (propertize "C-c C-r" 'face 'help-key-binding)
+                        (propertize ", Inspect: " 'face 'font-lock-string-face)
                         (propertize "C-c C-i" 'face 'help-key-binding)))
                (confirm-strings)
                ;; FIXME(tool) use a wrapper instead of a manual text-property search,
@@ -2328,16 +2332,46 @@ OV is the tool call dispatch overlay."
                          (overlay-end prompt-ov)))))
     (delete-overlay ov)))
 
+(defun gptel--reject-tool-calls-and-continue (&optional tool-calls ov)
+  "Reject pending TOOL-CALLS and continue the request chain.
+
+Feed a rejection message to the LLM for each tool call so the
+conversation can proceed.  OV is the tool call dispatch overlay."
+  (interactive (pcase-let ((`(,resp . ,o) (get-char-property-and-overlay
+                                           (point) 'gptel-tool)))
+                 (list resp o)))
+  (gptel--update-status " Tools rejected" 'error)
+  (when tool-calls
+    (let* ((default "Tool call rejected by user.")
+           (msg (read-string
+                 (format-prompt "Rejection message: " default)
+                 nil nil default)))
+      (cl-loop for (_tool-spec _arg-plist process-tool-result) in tool-calls
+               do (funcall process-tool-result msg))))
+  (when (and (overlayp ov) (overlay-buffer ov))
+    (with-current-buffer (overlay-buffer ov)
+      (when-let* ((preview-handles (overlay-get ov 'previews)))
+        (dolist (func-to-handle preview-handles)
+          (when (car func-to-handle) (apply func-to-handle))))
+      (dolist (prompt-ov (overlay-get ov 'prompt))
+        (when-let* (((overlay-buffer prompt-ov))
+                    (inhibit-read-only t))
+          (delete-region (overlay-start prompt-ov)
+                         (overlay-end prompt-ov)))))
+    (delete-overlay ov)))
+
 (defun gptel--dispatch-tool-calls (choice)
   "Dispatch on tool-calls with CHOICE."
   (interactive
    (list
     (let ((choices '((?y "yes") (?n "do nothing")
-                     (?k "cancel request") (?i "inspect call(s)"))))
+                     (?k "cancel request") (?r "reject (continue)")
+                     (?i "inspect call(s)"))))
       (read-multiple-choice "Run tool calls? " choices))))
   (pcase (car choice)
     (?y (call-interactively #'gptel--accept-tool-calls))
     (?k (call-interactively #'gptel--reject-tool-calls))
+    (?r (call-interactively #'gptel--reject-tool-calls-and-continue))
     (?i (call-interactively #'gptel--inspect-tool-calls))))
 
 ;;;; Tool call inspection UI
@@ -2345,6 +2379,7 @@ OV is the tool call dispatch overlay."
   :doc "Actions in the gptel tool inspection buffer."
   "C-c C-c" #'gptel--inspect-accept-tool-calls
   "C-c C-k" #'gptel--inspect-reject-tool-calls
+  "C-c C-r" #'gptel--inspect-reject-tool-calls-and-continue
   "C-c C-i" #'gptel--inspect-quit-tool-calls)
 
 (defun gptel--inspect-accept-tool-calls (&optional _)
@@ -2407,8 +2442,18 @@ This is a bug, please report it!"))))
   "Cancel tool-calls and return to query buffer."
   (interactive)
   (apply #'gptel--reject-tool-calls
-   (thread-first (gptel-fsm-info gptel--fsm-last)
-                 (plist-get :tool-display)))
+         (thread-first (gptel-fsm-info gptel--fsm-last)
+                       (plist-get :tool-display)))
+  (quit-window t))
+
+(defun gptel--inspect-reject-tool-calls-and-continue (&optional _)
+  "Reject tool-calls from the inspection buffer and continue the chain.
+
+Feed a rejection message to the LLM for each tool call and clean up."
+  (interactive)
+  (apply #'gptel--reject-tool-calls-and-continue
+         (thread-first (gptel-fsm-info gptel--fsm-last)
+                       (plist-get :tool-display)))
   (quit-window t))
 
 (defun gptel--inspect-quit-tool-calls (&optional _)
@@ -2492,6 +2537,8 @@ query buffer."
               " \\[gptel--inspect-accept-tool-calls], "
               (buttonize "Cancel" #'gptel--inspect-reject-tool-calls)
               " \\[gptel--inspect-reject-tool-calls], "
+              (buttonize "Reject" #'gptel--inspect-reject-tool-calls-and-continue)
+              " \\[gptel--inspect-reject-tool-calls-and-continue], "
               (buttonize "Return" #'gptel--inspect-quit-tool-calls)
               " \\[gptel--inspect-quit-tool-calls], "
               (buttonize "Edit" (lambda (_) (read-only-mode 'toggle)))


### PR DESCRIPTION
* gptel.el (gptel--reject-tool-calls-and-continue): New function that feeds "Tool call rejected by user." (or custom response from prompt) as all pending tool results and continues the REACT chain. (gptel--inspect-reject-tool-calls-and-continue): A counterpart of `gptel--inspect-reject-tool-calls' inside tool inspection buffer. (gptel-tool-call-actions-map):
(gptel--display-tool-calls):
(gptel-tool-call-inspection-map):
(gptel--inspect-tool-calls): Bind the rejection to C-c C-r and update help hints accordingly.
* NEWS (New features and UI changes): Document the new feature.

This feature is something I often miss when I see that the reasoning chain is getting in completely wrong direction and start doing crazy staff like editing files via python instead of using dedicated tools or simply trying to call heavy tool that will waste time, tokens, and lead to nothing.  Without this feature, the only option is canceling the whole reasoning chain, sometimes long and involving complicated finished tool calls like searching web or querying databases.