### PR TITLE
gptel-gh: Remove deprecated Copilot models

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,9 +10,9 @@
 
 - The models =gptel-5-1=, =gpt-5.1-codex=, =gpt-5.1-codex-max=,
   =gpt-5.1-codex-mini=, =gpt-5.2=, =gpt-5.2-codex=, =claude-sonnet-4=,
-  =gemini-3-pro-preview= and =grok-code-fast-1= have been removed from
-  the default list of Copilot models. These models are either deprecated
-  or no longer available.
+  =gemini-2.5-pro=, =gemini-3-pro-preview=, =gemini-3-flash-preview= and
+  =grok-code-fast-1= have been removed from the default list of Copilot
+  models. These models are either deprecated or no longer available.
 
 - The models =claude-3-7-sonnet-20250219=, =claude-3-5-sonnet-20241022=,
   =claude-3-5-sonnet-20240620=, =claude-3-5-haiku-20241022=,

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -158,26 +158,6 @@
      :input-cost 1
      :output-cost 1
      :cutoff-date "2026-01")
-    (gemini-2.5-pro
-     :description "Next gen, high speed, multimodal for a diverse variety of tasks"
-     :capabilities (tool-use json media)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                  "application/pdf" "text/plain" "text/csv" "text/html")
-     :context-window 109
-     :input-cost 1
-     :output-cost 1
-     :cutoff-date "2025-01")
-    (gemini-3-flash-preview
-     :description "Most intelligent Gemini model built for speed"
-     :capabilities (tool-use json media audio video)
-     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                  "application/pdf" "text/plain" "text/csv" "text/html"
-                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
-                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
-     :context-window 109
-     :input-cost 0.33
-     :output-cost 0.33
-     :cutoff-date "2025-01")
     (gemini-3.1-pro-preview
      :description "Most intelligent Gemini model with SOTA reasoning and multimodal understanding"
      :capabilities (tool-use json media audio video)


### PR DESCRIPTION
Both `gemini-2.5-pro` and `gemini-3-flash-preview` are deprecated as of today (https://docs.github.com/en/copilot/reference/ai-models/supported-models#model-retirement-history)