### PR TITLE
Remove Github Models docs and mentions (service retired)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
 
 ** Breaking changes
 
+- The Github Models setup instructions have been removed from the
+  README, and the Github Models mentions in gptel.el's commentary
+  header removed.  GitHub Models was fully retired on 2026-07-30 and
+  its API is no longer available.
+
 - The models =deepseek-chat= and =deepseek-reasoner= have been
   removed from the default list of Deepseek models.  These models are
   either deprecated or no longer available.

--- a/README.org
+++ b/README.org
@@ -88,7 +88,6 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
       - [[#deepseek][DeepSeek]]
       - [[#sambanova-deepseek][Sambanova (Deepseek)]]
       - [[#cerebras][Cerebras]]
-      - [[#github-models][Github Models]]
       - [[#novita-ai][Novita AI]]
       - [[#xai][xAI]]
       - [[#aiml-api][AI/ML API]]
@@ -224,7 +223,6 @@ gptel supports a number of LLM providers:
 | DeepSeek             | [[https://platform.deepseek.com/api_keys][API key]]                    |
 | Sambanova (Deepseek) | [[https://cloud.sambanova.ai/apis][API key]]                    |
 | Cerebras             | [[https://cloud.cerebras.ai/][API key]]                    |
-| Github Models        | [[https://github.com/settings/tokens][Token]]                      |
 | Novita AI            | [[https://novita.ai/model-api/product/llm-api?utm_source=github_gptel&utm_medium=github_readme&utm_campaign=link][Token]]                      |
 | xAI                  | [[https://console.x.ai?utm_source=github_gptel&utm_medium=github_readme&utm_campaign=link][API key]]                    |
 | GitHub CopilotChat   | GitHub account             |
@@ -1003,47 +1001,6 @@ The above code makes the backend available to select.  If you want it to be the 
         :key "your-api-key"
         :models '(llama3.1-70b
                   llama3.1-8b)))
-#+end_src
-
-#+html: </details>
-#+html: <details><summary>
-**** Github Models
-#+html: </summary>
-
-NOTE:  [[https://docs.github.com/en/github-models/about-github-models][GitHub Models]] is /not/ GitHub Copilot!  If you want to use GitHub Copilot chat via gptel, look at the instructions for GitHub CopilotChat below instead.
-
-Register a backend with
-
-#+begin_src emacs-lisp
-  ;; Github Models offers an OpenAI compatible API
-  (gptel-make-openai "Github Models" ;Any name you want
-    :host "models.inference.ai.azure.com"
-    :endpoint "/chat/completions?api-version=2024-05-01-preview"
-    :stream t
-    :key "your-github-token"
-    :models '(gpt-4o))
-#+end_src
-
-You will need to create a github [[https://github.com/settings/personal-access-tokens][token]].
-
-For all the available models, check the [[https://github.com/marketplace/models][marketplace]].
-
-You can pick this backend from the menu when using (see [[#usage][Usage]]).
-
-***** (Optional) Set as the default gptel backend
-
-The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.
-
-#+begin_src emacs-lisp
-  ;; OPTIONAL configuration
-  (setq gptel-model  'gpt-4o
-        gptel-backend
-        (gptel-make-openai "Github Models" ;Any name you want
-          :host "models.inference.ai.azure.com"
-          :endpoint "/chat/completions?api-version=2024-05-01-preview"
-          :stream t
-          :key "your-github-token"
-          :models '(gpt-4o))
 #+end_src
 
 #+html: </details>

--- a/gptel.el
+++ b/gptel.el
@@ -35,7 +35,7 @@
 ;; gptel supports:
 ;;
 ;; - The services ChatGPT, Azure, Gemini, Anthropic AI, Together.ai, Perplexity,
-;;   AI/ML API, Anyscale, OpenRouter, Groq, PrivateGPT, DeepSeek, Cerebras, Github Models,
+;;   AI/ML API, Anyscale, OpenRouter, Groq, PrivateGPT, DeepSeek, Cerebras,
 ;;   GitHub Copilot chat, AWS Bedrock, Novita AI, xAI, Sambanova, Mistral Le
 ;;   Chat and Kagi (FastGPT & Summarizer).
 ;; - Local models via Ollama, Llama.cpp, Llamafiles or GPT4All
@@ -71,8 +71,8 @@
 ;; - For Azure: define a gptel-backend with `gptel-make-azure'.
 ;; - For Gemini: define a gptel-backend with `gptel-make-gemini'.
 ;; - For Anthropic (Claude): define a gptel-backend with `gptel-make-anthropic'.
-;; - For AI/ML API, Together.ai, Anyscale, Groq, OpenRouter, DeepSeek, Cerebras
-;;   or Github Models: define a gptel-backend with `gptel-make-openai'.
+;; - For AI/ML API, Together.ai, Anyscale, Groq, OpenRouter, DeepSeek or
+;;   Cerebras: define a gptel-backend with `gptel-make-openai'.
 ;; - For PrivateGPT: define a backend with `gptel-make-privategpt'.
 ;; - For Perplexity: define a backend with `gptel-make-perplexity'.
 ;; - For Deepseek: define a backend with `gptel-make-deepseek'.


### PR DESCRIPTION
GitHub Models was fully retired on 2026-07-30 — per GitHub's own docs, the playground, model catalog, inference API, and BYOK are no longer available to any customer: https://docs.github.com/en/github-models

This removes the now-dead setup instructions:
- The "Github Models" TOC entry, API-key table row, and full `**** Github Models` details section in README.org (the `gptel-make-openai` snippet there points at `models.inference.ai.azure.com`, which no longer works for anyone copying it).
- The two "Github Models" mentions in `gptel.el`'s commentary header.
- A NEWS entry under Breaking changes noting the removal.

No code paths are affected — `gptel-make-openai` remains a generic OpenAI-compatible-API constructor, nothing hardcodes the GitHub Models endpoint elsewhere.

Closes #1501

---
Disclosure: this PR (code and description) was prepared with AI assistance and reviewed by me before submitting.