### PR TITLE
gptel-openai-oauth: Carry model capabilities

### DIFF
--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -23,6 +23,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'gptel-openai)
 (require 'gptel-openai-responses)
 (require 'gptel-oauth)
 

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -402,6 +402,17 @@ before constructing the headers."
        ("Originator"    . "gptel"))
      (and account-id `(("ChatGPT-Account-Id" . ,account-id))))))
 
+(defconst gptel--openai-oauth-models
+  (mapcar (lambda (name) (or (assq name gptel--openai-models) name))
+          '( gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini
+             gpt-5.4 gpt-5.5 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna))
+  "List of ChatGPT subscription models and their capabilities.
+
+Each model is looked up in `gptel--openai-models', so that the
+models served by the Codex endpoint carry the same specifications
+as their API counterparts.  A model absent from that table is
+included as a bare symbol, and has no known capabilities.")
+
 ;;;###autoload
 (cl-defun gptel-make-openai-oauth
     (name &key curl-args (stream t) request-params
@@ -409,9 +420,7 @@ before constructing the headers."
           (host "chatgpt.com")
           (protocol "https")
           (endpoint "/backend-api/codex/responses")
-          (models
-           '( gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini
-              gpt-5.4 gpt-5.5 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna)))
+          (models gptel--openai-oauth-models))
   "Register a ChatGPT Plus/Pro OAuth backend for gptel with NAME.
 
 This backend uses ChatGPT OAuth tokens (not OpenAI API keys) and


### PR DESCRIPTION
The models registered by `gptel-make-openai-oauth` are named as bare
symbols, so `gptel--process-models` has no specifications to attach to
them and they end up with empty symbol plists. Every capability check
against a model on this backend then fails, including for models whose
capabilities `gptel--openai-models` already describes.

Three effects, on a freshly registered backend:

- `gptel-add-file` on an image answers "Ignoring unsupported binary
  file", because `gptel-context--add-binary-file` checks
  `gptel--model-capable-p`.
- `gptel-track-media` never follows an image link in a chat buffer,
  because the MIME check in `gptel--parse-media-links` fails.
- The model menu shows neither a description nor a context window,
  since `gptel--infix-provider` reads both off the model symbol.

To reproduce, on master:

```elisp
(let ((backend (gptel-make-openai-oauth "Codex")))
  (mapcar (lambda (m) (cons m (gptel--model-capabilities m)))
          (gptel-backend-models backend)))
;; => ((gpt-5.2) (gpt-5.3-codex) ... (gpt-5.6-luna))   ;; all empty
```

This adds `gptel--openai-oauth-models`, following the
`gptel--<backend>-models` convention, which looks each name up in
`gptel--openai-models`. The advertised list and its order are
unchanged, and a model with no entry in that table — `gpt-5.3-codex`
and `gpt-5.3-codex-spark` are the two today — is still included as a
bare symbol.

After the change:

```
gpt-5.2                media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.3-codex          media=no   mimes=-
gpt-5.3-codex-spark    media=no   mimes=-
gpt-5.4-mini           media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.4                media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.5                media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.6-sol            media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.6-terra          media=yes  mimes=(image/jpeg image/png image/gif image/webp)
gpt-5.6-luna           media=yes  mimes=(image/jpeg image/png image/gif image/webp)
```

I have been using the fix against a ChatGPT subscription: images now
reach `gpt-5.6-sol` through the Codex endpoint and are described
correctly, and follow-up questions in the same chat buffer resend the
image as expected.
