### PR TITLE
gptel-anthropic: Handle mid-stream event: error

### DIFF
--- a/gptel-anthropic.el
+++ b/gptel-anthropic.el
@@ -167,7 +167,14 @@ information if the stream contains it.  Not my best work, I know."
               (plist-put info :stop-reason
                          (map-nested-elt response '(:delta :stop_reason)))
               ;; Capture token usage
-              (gptel--anthropic-update-tokens (plist-get response :usage) info)))))
+              (gptel--anthropic-update-tokens (plist-get response :usage) info)))
+           ;; In-band error event: HTTP 200 but the stream signals failure
+           ;; (e.g. `overloaded_error').  Treat it like an HTTP-level error.
+           ((looking-at "error")
+            (forward-line 1) (forward-char 5)
+            (when-let* ((err (plist-get (gptel--json-read) :error))
+                        ((not (eq err :null))))
+              (plist-put info :error err)))))
       (error (goto-char pt)))
     (let ((response-text (apply #'concat (nreverse content-strs))))
       (unless (string-empty-p response-text)


### PR DESCRIPTION
Anthropic can return HTTP 200 and begin a stream, then signal failure in-band with an event: error block (e.g. overloaded_error).  The stream parser had no case for it, so the error was silently swallowed and the request finished as if it had succeeded.

Set :error from the event payload so the request is routed through the existing error path (status, message, post-response hooks).