### PR TITLE
gptel-request: Call gptel-post-request-hook in corresponding buffer

### DIFF
--- a/gptel-request.el
+++ b/gptel-request.el
@@ -1901,16 +1901,17 @@ MACHINE is an instance of `gptel-fsm'"
   ;; Reset some flags in info.  This is necessary when reusing fsm's context for
   ;; a second network request: gptel tests for the presence of these flags to
   ;; handle state transitions.  (NOTE: Don't add :uuid to this.)
-  (let ((info (gptel-fsm-info fsm)))
+  (let ((req-info (gptel-fsm-info fsm)))
     (dolist (key '(:tool-result :tool-use :error :http-status :reasoning :tokens))
-      (when (plist-get info key)
-        (plist-put info key nil))))
-  (funcall
-   (if gptel-use-curl
-       #'gptel-curl-get-response
-     #'gptel--url-get-response)
-   fsm)
-  (run-hooks 'gptel-post-request-hook))
+      (when (plist-get req-info key)
+        (plist-put req-info key nil)))
+    (funcall
+     (if gptel-use-curl
+         #'gptel-curl-get-response
+       #'gptel--url-get-response)
+     fsm)
+    (with-current-buffer (plist-get req-info :buffer)
+      (run-hooks 'gptel-post-request-hook))))
 
 (defun gptel--process-tool-call (fsm tool-spec tool-call result)
   "Add tool RESULT to a TOOL-CALL and transition FSM if required.


### PR DESCRIPTION
Hi, I think calling this hook in the caller buffer can be helpful for what the the hooks would want to do.  Without this PR, the current buffer would be randomly chosen, so there is no easy way AFAIK to know which buffer instantiates this gptel-request.

For example, I want to read some buffer-local variables in the chat buffer.

Also it's possible now to search for the corresponding FSM to figure out the runtime configurations, if the user wants to.

Thanks in advance!