### PR TITLE
gptel-oauth: Extract generic auth-code callback handling, support SSH

### DIFF
--- a/gptel-oauth.el
+++ b/gptel-oauth.el
@@ -121,6 +121,103 @@ If your browser does not open automatically, browse to %s: "
        (format "(One-time code %s copied) Press ENTER after authorizing: "
                user-code)))))
 
+(defun gptel-oauth--read-code (authorization-url redirect-path state port timeout)
+  "Open AUTHORIZATION-URL and return an OAuth authorization code.
+
+REDIRECT-PATH and STATE validate the callback.  PORT specifies the
+loopback callback server and TIMEOUT is the maximum wait in seconds.
+When running over SSH, prompt for the callback URL after authorization
+instead of starting a local server."
+  (cl-labels
+      ((callback-code (target)
+         (let* ((query-start (string-search "?" target))
+                (path (if query-start (substring target 0 query-start) target))
+                (query (and query-start
+                            (url-parse-query-string
+                             (substring target (1+ query-start)))))
+                (callback-state (cadr (assoc "state" query)))
+                (callback-code (cadr (assoc "code" query)))
+                (callback-error (cadr (assoc "error" query)))
+                (callback-error-description
+                 (cadr (assoc "error_description" query))))
+           (cond
+            ((not (equal path redirect-path))
+             (user-error "This is not an OAuth callback"))
+            (callback-error
+             (user-error "%s" (or callback-error-description callback-error)))
+            ((not (equal callback-state state))
+             (user-error "OAuth state did not match"))
+            (callback-code)
+            (t (user-error "OAuth callback did not include a code")))))
+       (send-response (process status title body)
+         (let ((payload (format "<!doctype html><meta charset=\"utf-8\"><title>%s</title><p>%s</p>"
+                                title body)))
+           (process-send-string
+            process
+            (format "HTTP/1.1 %s %s\r\nContent-Type: text/html; \\
+charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+                    status title (string-bytes payload) payload)))))
+    (if (or (getenv "SSH_CLIENT")
+            (getenv "SSH_CONNECTION")
+            (getenv "SSH_TTY"))
+        (progn
+          (message "OAuth authorization URL: %s" authorization-url)
+          (ignore-errors (gui-set-selection 'CLIPBOARD authorization-url))
+          (callback-code
+           (url-filename
+            (url-generic-parse-url
+             (read-from-minibuffer
+              "OAuth URL copied to clipboard.  Open it in your local browser \
+and authorize, then paste the callback URL from the browser's address bar: ")))))
+      (let ((deadline (+ (float-time) timeout))
+            code error server)
+        (cl-labels
+            ((finish (process status title body &optional result failure)
+               (send-response process status title body)
+               (when result (setq code result))
+               (when failure (setq error failure))
+               (delete-process process))
+             (filter (process string)
+               (let ((request (concat (or (process-get process :gptel-request) "")
+                                      string)))
+                 (process-put process :gptel-request request)
+                 (when (string-match-p "\r\n\r\n" request)
+                   (condition-case err
+                       (finish process "200" "OAuth Complete"
+                               "OAuth authorization succeeded.  You may close this tab."
+                               (and (string-match "\\`GET \\([^ ]+\\) HTTP/" request)
+                                    (callback-code (match-string 1 request))))
+                     (user-error
+                      (finish process "400" "OAuth Error"
+                              "OAuth authorization failed.  You may close this tab."
+                              nil (error-message-string err))))))))
+          (unwind-protect
+              (progn
+                (setq server
+                      (make-network-process
+                       :name "gptel-oauth-callback"
+                       :server t
+                       :host "localhost"
+                       :service port
+                       :filter #'filter
+                       :noquery t))
+                (message "OAuth authorization URL: %s" authorization-url)
+                (ignore-errors (gui-set-selection 'CLIPBOARD authorization-url))
+                (read-from-minibuffer
+                 (format "OAuth URL copied to clipboard.  \
+Press ENTER to open the authorization page.  \
+If your browser does not open automatically, browse to %s: "
+                         authorization-url))
+                (browse-url authorization-url)
+                (while (and (not code) (not error) (< (float-time) deadline))
+                  (accept-process-output nil 1))
+                (cond
+                 (code code)
+                 (error (user-error "%s" error))
+                 (t (user-error "Timed out waiting for OAuth callback"))))
+            (when (process-live-p server)
+              (delete-process server))))))))
+
 ;;; URL / JWT helpers
 
 (defun gptel-oauth--jwt-payload (jwt-string)

--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -38,9 +38,10 @@
   "OAuth login method used by `gptel-openai-oauth-login'.
 
 The `authorization-code' method uses OAuth 2.0 Authorization Code
-Flow with PKCE and a localhost callback.  It is not supported when
-Emacs is running over SSH.  The `device' method uses OAuth 2.0
-Device Authorization Grant."
+Flow with PKCE and a localhost callback.  When Emacs is running
+over SSH the callback URL has to be copied from the browser into
+Emacs manually.  The `device' method uses OAuth 2.0 Device
+Authorization Grant."
   :type '(choice (const :tag "Authorization Code Flow with PKCE" authorization-code)
                  (const :tag "Device Authorization Grant" device))
   :group 'gptel)
@@ -164,108 +165,12 @@ included in the authorization request and checked in the callback."
       ("state" ,state)
       ("originator" "gptel")))))
 
-(defun gptel--openai-oauth-callback-request (request)
-  "Parse callback REQUEST and return a plist with :path and :query."
-  (when (string-match "\\`GET \\([^ ]+\\) HTTP/" request)
-    (let* ((target (match-string 1 request))
-           (query-start (string-search "?" target))
-           (path (if query-start
-                     (substring target 0 query-start)
-                   target))
-           (query (and query-start
-                       (substring target (1+ query-start)))))
-      (list :path path
-            :query (and query (url-parse-query-string query))))))
-
-(defun gptel--openai-oauth-send-callback-response (process status title body)
-  "Send PROCESS an HTTP response with STATUS, TITLE and BODY."
-  (let ((payload (format "<!doctype html><meta charset=\"utf-8\"><title>%s</title><p>%s</p>"
-                         title body)))
-    (process-send-string
-     process
-     (format "HTTP/1.1 %s %s\r\nContent-Type: text/html; \
-charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
-             status title (string-bytes payload) payload))))
-
-;; TODO: Support over SSH connections can be added by (i) not starting a server,
-;; and (ii) asking the user to copy the callback URL from the browser's URL bar
-;; into Emacs.
 (defun gptel--openai-oauth-read-code (authorization-url state)
-  "Open AUTHORIZATION-URL and wait for a localhost callback matching STATE."
-  (when (or (getenv "SSH_CLIENT")
-            (getenv "SSH_CONNECTION")
-            (getenv "SSH_TTY"))
-    (user-error
-     (concat "OpenAI authorization-code login requires a local browser "
-             "callback and is not supported over SSH.  Set "
-             "`gptel-openai-oauth-login-method' to `device' and retry")))
-  (let ((deadline (+ (float-time) gptel--openai-oauth-redirect-timeout))
-        code error server)
-    (cl-labels
-        ((finish (process status title body &optional result failure)
-           (gptel--openai-oauth-send-callback-response process status title body)
-           (when result (setq code result))
-           (when failure (setq error failure))
-           (delete-process process))
-         (filter (process string)
-           (let ((request (concat (or (process-get process :gptel-request) "")
-                                  string)))
-             (process-put process :gptel-request request)
-             (when (string-match-p "\r\n\r\n" request)
-               (pcase-let* ((`(:path ,path :query ,query)
-                             (gptel--openai-oauth-callback-request request))
-                            (callback-state (cadr (assoc "state" query)))
-                            (callback-code (cadr (assoc "code" query)))
-                            (callback-error (cadr (assoc "error" query)))
-                            (callback-error-description
-                             (cadr (assoc "error_description" query))))
-                 (cond
-                  ((not (equal path gptel--openai-oauth-redirect-path))
-                   (finish process "404" "Not Found"
-                           "This is not an OpenAI OAuth callback."))
-                  (callback-error
-                   (finish process "400" "OpenAI OAuth Error"
-                           "OpenAI OAuth authorization failed.  You may close this tab."
-                           nil
-                           (or callback-error-description callback-error)))
-                  ((not (equal callback-state state))
-                   (finish process "400" "OpenAI OAuth Error"
-                           "OpenAI OAuth state did not match.  You may close this tab."
-                           nil "OpenAI OAuth state did not match"))
-                  (callback-code
-                   (finish process "200" "OpenAI OAuth Complete"
-                           "OpenAI OAuth authorization succeeded.  You may close this tab."
-                           callback-code))
-                  (t
-                   (finish process "400" "OpenAI OAuth Error"
-                           "OpenAI OAuth callback did not include a code.  You may close this tab."
-                           nil "OpenAI OAuth callback did not include a code"))))))))
-      (unwind-protect
-          (progn
-            (setq server
-                  (make-network-process
-                   :name "gptel-openai-oauth-callback"
-                   :server t
-                   :host "localhost"
-                   :service gptel--openai-oauth-redirect-port
-                   :filter #'filter
-                   :noquery t))
-            (message "OpenAI OAuth authorization URL: %s" authorization-url)
-            (ignore-errors (gui-set-selection 'CLIPBOARD authorization-url))
-            (read-from-minibuffer
-             (format "OpenAI OAuth URL copied to clipboard.  \
-Press ENTER to open the authorization page.  \
-If your browser does not open automatically, browse to %s: "
-                     authorization-url))
-            (browse-url authorization-url)
-            (while (and (not code) (not error) (< (float-time) deadline))
-              (accept-process-output nil 1))
-            (cond
-             (code code)
-             (error (user-error "%s" error))
-             (t (user-error "Timed out waiting for OpenAI OAuth callback"))))
-        (when (process-live-p server)
-          (delete-process server))))))
+  "Open AUTHORIZATION-URL and return an authorization code matching STATE."
+  (gptel-oauth--read-code authorization-url
+                          gptel--openai-oauth-redirect-path state
+                          gptel--openai-oauth-redirect-port
+                          gptel--openai-oauth-redirect-timeout))
 
 (defun gptel--openai-oauth-login-with-authorization-code (backend)
   "Authenticate BACKEND using OpenAI Authorization Code Flow with PKCE."


### PR DESCRIPTION
Follow-up to #1463

1. **Extract the callback server logic into `gptel-oauth.el` .**
   `gptel--openai-oauth-read-code` now delegates to a new generic
   `gptel-oauth--read-code (authorization-url redirect-path state port timeout)`.
   It handles the loopback server, request parsing, path/state/error/code
   validation and the HTTP response, so other backends (e.g. Claude) can reuse it.
   OpenAI-specific pieces (authorization URL, constants, token exchange) are unchanged.

2. **Allow auth-code OAuth over SSH.**
   Over SSH no server is started. The user opens the authorization URL in their
   local browser, lets the callback fail there, and pastes the callback URL from
   the address bar into Emacs. That URL goes through the same validation as the
   server callback, so the rest of the handling is unchanged. The previous
   `user-error` blocking auth-code login over SSH and the corresponding TODO are removed.

Also updates the one `gptel-openai-oauth-login-method` docstring sentence that
said auth-code login was unsupported over SSH.

- Under `SSH_CLIENT` / `SSH_CONNECTION` / `SSH_TTY` , the `make-network-process=`server branch is skipped entirely.
-  The authorization URL is shown/copied, and `read-from-minibuffer` asks the user to paste the callback URL from the browser's address bar. That URL is parsed with `url-generic-parse-url` and validated by the same path/state/error/code logic used for the server callback.

#### Authorization Code login over SSH

Two machines are involved:

- **Remote host** — where Emacs runs, reached over SSH. No browser.
- **Local machine** — where the user's terminal and browser run. "localhost"
  in the browser refers to this machine.

Steps:

1. Emacs (on the remote host) builds the authorization URL, copies it to the
   clipboard and displays it. It does not start a callback server and does not
   open a browser, since a server on the remote host would be unreachable from
   the user's browser.

2. The user opens that URL in the browser on the local machine.

3. The user authorizes with OpenAI. OpenAI redirects the browser to the
   registered callback: `http://localhost:1455/auth/callback?code=...&state=...`

4. The page fails to load, because nothing is listening on port 1455 on the
   local machine. The address bar still contains the full callback URL,
   including `code` and `state`.

5. The user copies the URL from the address bar and pastes it at the Emacs
   minibuffer prompt on the remote host.

6. Emacs parses the pasted URL, verifies the callback path and `state`, reports
   any `error`/`error_description`, extracts `code`, and exchanges it for a
   token — identical to the handling in the local-server flow.

Haven't tested it yet as I do not run Emacs over ssh. Need help testing.