### PR TITLE
feat: add OrcaRouter backend

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -83,6 +83,10 @@
 - xAI backend: Add support for =grok-4.3=, =grok-build-0.1= and
   =grok-4.5=.
 
+- New backend: OrcaRouter, a gateway that routes requests to models
+  from many providers through a single OpenAI-compatible API.  Define
+  it with ~gptel-make-orcarouter~.
+
 ** New features and UI changes
 
 - The gptel tool's =:include= slot and the global option

--- a/README.org
+++ b/README.org
@@ -90,6 +90,7 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
       - [[#cerebras][Cerebras]]
       - [[#novita-ai][Novita AI]]
       - [[#xai][xAI]]
+      - [[#orcarouter][OrcaRouter]]
       - [[#aiml-api][AI/ML API]]
       - [[#github-copilotchat][GitHub CopilotChat]]
       - [[#aws-bedrock][AWS Bedrock]]
@@ -225,6 +226,7 @@ gptel supports a number of LLM providers:
 | Cerebras             | [[https://cloud.cerebras.ai/][API key]]                    |
 | Novita AI            | [[https://novita.ai/model-api/product/llm-api?utm_source=github_gptel&utm_medium=github_readme&utm_campaign=link][Token]]                      |
 | xAI                  | [[https://console.x.ai?utm_source=github_gptel&utm_medium=github_readme&utm_campaign=link][API key]]                    |
+| OrcaRouter           | [[https://www.orcarouter.ai][API key]]                    |
 | GitHub CopilotChat   | GitHub account             |
 | Bedrock              | AWS credentials            |
 | Moonshot (Kimi)      | API key ([[https://platform.moonshot.cn/console][CN]] or [[https://platform.moonshot.ai/console][Global]])     |
@@ -1070,6 +1072,37 @@ The above code makes the backend available to select.  If you want it to be the 
       (gptel-make-xai "xAI"               ; Any name you want
         :key "your-api-key" ; can be a function that returns the key
         :stream t))
+#+end_src
+
+#+html: </details>
+#+html: <details><summary>
+**** OrcaRouter
+#+html: </summary>
+
+[[https://www.orcarouter.ai][OrcaRouter]] is a gateway that routes requests to models from many providers through a single OpenAI-compatible API.  It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Register a backend with
+
+#+begin_src emacs-lisp
+(gptel-make-orcarouter "OrcaRouter"   ;Any name you want
+  :stream t                           ;for streaming responses
+  :key "your-api-key")               ;can be a function that returns the key
+#+end_src
+
+You can pick this backend from the menu when using gptel (see [[#usage][Usage]]).
+
+The default models are the gateway's smart-routing presets: =orcarouter/auto=, =orcarouter/fusion=, =orcarouter/fusion-flash= and =orcarouter/fusion-mini=.
+
+***** (Optional) Set as the default gptel backend
+
+The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.
+
+#+begin_src emacs-lisp
+;; OPTIONAL configuration
+(setq gptel-model   'orcarouter/auto
+      gptel-backend (gptel-make-orcarouter "OrcaRouter"
+                      :stream t
+                      :key "your-api-key"))
 #+end_src
 
 #+html: </details>

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -424,6 +424,80 @@ see `gptel-make-openai'."
     backend))
 
 
+;;; OrcaRouter
+;;;###autoload
+(cl-defstruct (gptel-orcarouter (:include gptel-openai)
+                                (:copier nil)
+                                (:constructor gptel--make-orcarouter)))
+
+(cl-defmethod gptel--request-data :around ((_backend gptel-orcarouter) _prompts)
+  "Modify how structured output JSON schema is specified.
+
+This method works by wrapping the main implementation, passing PROMPTS.
+OrcaRouter is a multi-vendor gateway whose smart-routed upstreams
+currently honor `json_object' rather than `json_schema', so translate
+the schema into a `json_object' request plus a system-prompt hint."
+  (let ((prompts-plist (cl-call-next-method)))
+    (when gptel--schema
+      (let ((response-format
+             (prin1-to-string (plist-get prompts-plist :response_format))))
+        (plist-put prompts-plist :response_format (list :type "json_object"))
+        (cl-callf (lambda (system)
+                    (concat system
+                            "\n\n<response_format>Required JSON schema for response:\n\n"
+                            response-format "\n</response_format>"))
+            (plist-get (aref (plist-get prompts-plist :messages) 0) :content))))
+    prompts-plist))
+
+;;;###autoload
+(cl-defun gptel-make-orcarouter
+    (name &key curl-args stream key request-params
+          (header (lambda (_info)
+                    (when-let* ((key (gptel--get-api-key)))
+                      `(("Authorization" . ,(concat "Bearer " key))))))
+          (host "api.orcarouter.ai")
+          (protocol "https")
+          (endpoint "/v1/chat/completions")
+          (models
+           '((orcarouter/auto
+              :description "Smart routing: picks the best model for each request"
+              :capabilities (tool reasoning)
+              :context-window 1000)
+             (orcarouter/fusion
+              :description "Long-context flagship routed by OrcaRouter"
+              :capabilities (tool reasoning)
+              :context-window 1000)
+             (orcarouter/fusion-flash
+              :description "Fast long-context model routed by OrcaRouter"
+              :capabilities (tool reasoning)
+              :context-window 200)
+             (orcarouter/fusion-mini
+              :description "Efficient long-context model routed by OrcaRouter"
+              :capabilities (tool reasoning)
+              :context-window 1000))))
+  "Register an OrcaRouter backend for gptel with NAME.
+
+OrcaRouter is a gateway that routes requests to models from many
+providers through a single OpenAI-compatible API.
+
+For the meanings of the keyword arguments, see `gptel-make-openai'."
+  (declare (indent 1))
+  (let ((backend (gptel--make-orcarouter
+                  :name name
+                  :host host
+                  :header header
+                  :key key
+                  :models (gptel--process-models models)
+                  :protocol protocol
+                  :endpoint endpoint
+                  :stream stream
+                  :request-params request-params
+                  :curl-args curl-args
+                  :url (concat protocol "://" host endpoint))))
+    (setf (alist-get name gptel--known-backends nil nil #'equal) backend)
+    backend))
+
+
 (provide 'gptel-openai-extras)
 ;;; gptel-openai-extras.el ends here
 

--- a/gptel.el
+++ b/gptel.el
@@ -36,8 +36,8 @@
 ;;
 ;; - The services ChatGPT, Azure, Gemini, Anthropic AI, Together.ai, Perplexity,
 ;;   AI/ML API, Anyscale, OpenRouter, Groq, PrivateGPT, DeepSeek, Cerebras,
-;;   GitHub Copilot chat, AWS Bedrock, Novita AI, xAI, Sambanova, Mistral Le
-;;   Chat and Kagi (FastGPT & Summarizer).
+;;   GitHub Copilot chat, AWS Bedrock, Novita AI, xAI, OrcaRouter, Sambanova,
+;;   Mistral Le Chat and Kagi (FastGPT & Summarizer).
 ;; - Local models via Ollama, Llama.cpp, Llamafiles or GPT4All
 ;;
 ;; Additionally, any LLM service (local or remote) that provides an
@@ -76,6 +76,7 @@
 ;; - For PrivateGPT: define a backend with `gptel-make-privategpt'.
 ;; - For Perplexity: define a backend with `gptel-make-perplexity'.
 ;; - For Deepseek: define a backend with `gptel-make-deepseek'.
+;; - For OrcaRouter: define a backend with `gptel-make-orcarouter'.
 ;; - For Kagi: define a gptel-backend with `gptel-make-kagi'.
 ;;
 ;; For local models using Ollama, Llama.cpp or GPT4All:


### PR DESCRIPTION
## Summary

Add a named [OrcaRouter](https://www.orcarouter.ai) backend to gptel, mirroring the existing DeepSeek and xAI OpenAI-compatible gateway constructors. OrcaRouter is a gateway that routes requests to models from many providers through a single OpenAI-compatible API at `https://api.orcarouter.ai/v1`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `gptel-openai-extras.el`: new `gptel-make-orcarouter` constructor (and a `gptel-orcarouter` backend struct) registering a named backend at `https://api.orcarouter.ai/v1/chat/completions`, with the gateway's smart-routing presets as default models:
  - `orcarouter/auto` — smart routing, picks the best model per request
  - `orcarouter/fusion` — long-context flagship
  - `orcarouter/fusion-flash` — fast long-context
  - `orcarouter/fusion-mini` — efficient long-context
  - Structured output is translated to `json_object`, which the gateway's smart-routed upstreams honor.
- `README.org`: OrcaRouter row in the provider table, TOC entry, and a new "OrcaRouter" section with setup examples.
- `gptel.el`: add OrcaRouter to the supported-services commentary.
- `NEWS`: note the new backend.

## Verification

- `emacs --batch` byte-compiles all `.el` files with no new errors; `gptel-make-orcarouter` registers the backend correctly.
- Live test against the real gateway through gptel's request path (POST `https://api.orcarouter.ai/v1/chat/completions`, model `orcarouter/auto`) returns HTTP 200 with `ORCA-LIVE-OK`; all four default models are confirmed on the gateway's `/v1/models` catalog.

Disclosure: I'm an engineer on the OrcaRouter team.
