### PR TITLE
gptel-openai-extras: Add deepseek-v4-flash-vision-exp

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -83,6 +83,8 @@
 - OpenAI backend: Add support for =gpt-5.6-sol=, =gpt-5.6-terra= and
   =gpt-5.6-luna=.
 
+- Deepseek backend: Add support for =deepseek-v4-flash-vision-exp=.
+
 - xAI backend: Add support for =grok-4.3=, =grok-build-0.1= and
   =grok-4.5=.
 

--- a/gptel-openai-extras.el
+++ b/gptel-openai-extras.el
@@ -333,15 +333,21 @@ This method works by wrapping the main implementation, passing PROMPTS."
           (protocol "https")
           (endpoint "/v1/chat/completions")
           (models '((deepseek-v4-flash
-                     :capabilities (tool reasoning)
+                     :capabilities (tool-use reasoning)
                      :context-window 1000
                      :input-cost 0.14
                      :output-cost 0.28)
                     (deepseek-v4-pro
-                     :capabilities (tool reasoning)
+                     :capabilities (tool-use reasoning)
                      :context-window 1000
                      :input-cost 0.435
-                     :output-cost 0.87))))
+                     :output-cost 0.87)
+                    (deepseek-v4-flash-vision-exp
+                     :capabilities (media tool-use reasoning url)
+                     :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+                     :context-window 1000
+                     :input-cost 0.14
+                     :output-cost 0.28))))
   "Register a DeepSeek backend for gptel with NAME.
 
 For the meanings of the keyword arguments, see `gptel-make-openai'."


### PR DESCRIPTION
See https://api-docs.deepseek.com/guides/vision/

It's other parameters (cost etc) are the same as deepseek-v4-flash's

BTW, the cost for deepseek models has [changed](https://api-docs.deepseek.com/quick_start/pricing) recently, but AFAIK currently there is no way in gptel to express their peak/off-peak prices, so I didn't change them right now.