### PR TITLE
gptel-openai-oauth: Add specs for the two Codex models

### DIFF
--- a/gptel-openai-oauth.el
+++ b/gptel-openai-oauth.el
@@ -410,8 +410,21 @@ before constructing the headers."
           (protocol "https")
           (endpoint "/backend-api/codex/responses")
           (models
-           '( gpt-5.2 gpt-5.3-codex gpt-5.3-codex-spark gpt-5.4-mini
-              gpt-5.4 gpt-5.5 gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna)))
+           '( gpt-5.2
+              (gpt-5.3-codex
+               :description "Agentic coding model"
+               :capabilities (media tool-use json url responses-api)
+               :mime-types ("image/jpeg" "image/png" "image/gif" "image/webp")
+               :context-window 400
+               :input-cost 1.75
+               :output-cost 14
+               :cutoff-date "2025-08")
+              (gpt-5.3-codex-spark
+               :description "Low-latency version of GPT-5.3-Codex, text only"
+               :capabilities (tool-use json responses-api)
+               :context-window 128)
+              gpt-5.4-mini gpt-5.4 gpt-5.5 gpt-5.6-sol gpt-5.6-terra
+              gpt-5.6-luna)))
   "Register a ChatGPT Plus/Pro OAuth backend for gptel with NAME.
 
 This backend uses ChatGPT OAuth tokens (not OpenAI API keys) and


### PR DESCRIPTION
`gpt-5.3-codex` and `gpt-5.3-codex-spark` have no entry in
`gptel--openai-models`, so they reach `gptel--process-models` as bare symbols
and their plists stay empty. Selecting either leaves gptel believing the model
can do nothing: `gptel-add-file` refuses an image as an "unsupported binary
file", `gptel-track-media` skips image links, and the model menu shows no
description or context window.

Sources for the two specs:

- <https://developers.openai.com/api/docs/models/gpt-5.3-codex>
- <https://openai.com/index/introducing-gpt-5-3-codex-spark/>

`gpt-5.3-codex-spark` is a research preview whose pricing is not final, so it
gets no cost keys, and it is text only.

`gpt-5.3-codex` is also served on the public API, so it could equally live in
`gptel--openai-models`. I put it here because you said the properties for these
belong in `gptel-openai-oauth`; happy to move it if you'd rather the shared
table carried it.
