### PR TITLE
gptel-gemini, gptel-gh: Add gemini-3.8-flash and update Gemini models

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,9 +25,12 @@
   removed from the default list of Anthropic models.  These models are
   either deprecated or no longer available.
 
-- The models =gemini-3.1-flash-lite-preview= and =gemini-3-pro-preview=
-  have been removed from the default list of Gemini models.  These
-  models are no longer available.
+- The models =gemini-3.1-flash-lite-preview=, =gemini-3-pro-preview=,
+  =gemini-2.5-pro-preview-06-05=, =gemini-2.5-flash-preview-09-2025=,
+  =gemini-2.5-flash-lite-preview-09-2025=, =gemini-2.0-flash=,
+  =gemini-2.0-flash-exp= and =gemini-2.0-flash-thinking-exp= have been
+  removed from the default list of Gemini models.  These models are no
+  longer available.
 
 - The minimum required version of the =transient= package is now 0.7.8.
 
@@ -71,14 +74,15 @@
   =claude-opus-4-8=, =claude-opus-4-9=, =claude-opus-5= and
   =claude-fable-5=.
 
-- GitHub Copilot backend: Add support for =gemini-3.7-flash=,
-  =gemini-3.6-flash=, =gemini-3.5-flash=, =gpt-5.6-sol=,
-  =gpt-5.6-terra=, =gpt-5.6-luna=, =claude-opus-4.8=, =claude-sonnet-5=,
-  =claude-opus-5= and =claude-fable-5=.
+- GitHub Copilot backend: Add support for =gemini-3.8-flash=,
+  =gemini-3.7-flash=, =gemini-3.6-flash=, =gemini-3.5-flash=,
+  =gpt-5.6-sol=, =gpt-5.6-terra=, =gpt-5.6-luna=, =claude-opus-4.8=,
+  =claude-sonnet-5=, =claude-opus-5= and =claude-fable-5=.
 
-- Gemini backend: Add support for =gemini-3.7-flash=,
-  =gemini-3.6-flash=, =gemini-3.5-flash=, =gemini-3.5-flash-lite=,
-  =gemini-3.1-flash-lite= and deprecate the preview version.
+- Gemini backend: Add support for =gemini-3.8-flash=,
+  =gemini-3.7-flash=, =gemini-3.6-flash=, =gemini-3.5-flash=,
+  =gemini-3.5-flash-lite= and =gemini-3.1-flash-lite=.  Add deprecation
+  notices for =gemini-3.1-flash-lite= and =gemini-3-flash-preview=.
 
 - OpenAI backend: Add support for =gpt-5.6-sol=, =gpt-5.6-terra= and
   =gpt-5.6-luna=.

--- a/gptel-gemini.el
+++ b/gptel-gemini.el
@@ -471,6 +471,17 @@ Media files, if present, are placed in `gptel-context'."
       :input-cost 0.10
       :output-cost 0.40
       :cutoff-date "2025-01")
+     (gemini-3.8-flash
+      :description "Engineered for long-horizon software engineering, agents and critical reasoning"
+      :capabilities (tool-use json media audio video)
+      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                   "application/pdf" "text/plain" "text/csv" "text/html"
+                   "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                   "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+      :context-window 1048              ; 65536 output token limit
+      :input-cost 0.75                  ; 1.50 from 2027-01-01
+      :output-cost 3.75                 ; 7.50 from 2027-01-01
+      :cutoff-date "2026-09")
      (gemini-3.7-flash
       :description "Next generation reasoning model with customizable thinking configurations"
       :capabilities (tool-use json media audio video)
@@ -527,7 +538,7 @@ Media files, if present, are placed in `gptel-context'."
       :output-cost 12.00                ; 18.0 for >200k tokens
       :cutoff-date "2025-01")
      (gemini-3.1-flash-lite
-      :description "Most cost-efficient multimodal Gemini model, offering the fastest performance for high-frequency, lightweight tasks"
+      :description "DEPRECATED: Please use gemini-3.5-flash-lite instead"
       :capabilities (tool-use json media audio video)
       :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
                    "application/pdf" "text/plain" "text/csv" "text/html"
@@ -538,7 +549,7 @@ Media files, if present, are placed in `gptel-context'."
       :output-cost 1.50
       :cutoff-date "2025-01")
      (gemini-3-flash-preview
-      :description "Most intelligent Gemini model built for speed"
+      :description "DEPRECATED: Please use gemini-3.6-flash or gemini-3.8-flash instead"
       :capabilities (tool-use json media audio video)
       :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
                    "application/pdf" "text/plain" "text/csv" "text/html"
@@ -559,15 +570,6 @@ Media files, if present, are placed in `gptel-context'."
       :input-cost 1.25                  ; 2.50 for >200k tokens
       :output-cost 10.00                ; 15 for >200k tokens
       :cutoff-date "2025-01")
-     (gemini-2.5-pro-preview-06-05
-      :description "Most powerful thinking model with state-of-the-art performance"
-      :capabilities (tool-use json media)
-      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                   "application/pdf" "text/plain" "text/csv" "text/html")
-      :context-window 1048              ; 65536 output token limit
-      :input-cost 1.25                  ; 2.50 for >200k tokens
-      :output-cost 10.00                ; 15 for >200k tokens
-      :cutoff-date "2025-01")
      (gemini-2.5-flash
       :description "Best in terms of price-performance, with well-rounded capabilities"
       :capabilities (tool-use json media audio video)
@@ -579,18 +581,8 @@ Media files, if present, are placed in `gptel-context'."
       :input-cost 0.3
       :output-cost 2.50
       :cutoff-date "2025-01")
-     (gemini-2.5-flash-preview-09-2025
-      :description "DEPRECATED: Please use gemini-2.5-flash instead"
-      :capabilities (tool-use json media)
-      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                   "application/pdf" "text/plain" "text/csv" "text/html")
-      :context-window 1048              ; 65536 output token limit
-      :input-cost 0.15
-      :output-cost 0.60                 ; 3.50 for thinking
-      :cutoff-date "2025-01")
      (gemini-2.5-flash-lite
       :description "Fastest & cheapest 2.5 model, for high-volume, latency-sensitive tasks"
-      :capabilities (tool-use json media)
       :capabilities (tool-use json media audio video)
       :mime-types ("image/png" "image/jpeg" "image/webp" "application/pdf" "text/plain"
                    "audio/x-aac" "audio/flac" "audio/mp3" "audio/m4a" "audio/mpeg"
@@ -600,44 +592,7 @@ Media files, if present, are placed in `gptel-context'."
       :context-window 1048              ; 64000 output token limit
       :input-cost 0.10
       :output-cost 0.40
-      :cutoff-date "2025-01")
-     (gemini-2.5-flash-lite-preview-09-2025
-      :description "Fastest & cheapest 2.5 model, for high-volume, latency-sensitive tasks"
-      :capabilities (tool-use json media audio video)
-      :mime-types ("image/png" "image/jpeg" "image/webp" "application/pdf" "text/plain"
-                   "audio/x-aac" "audio/flac" "audio/mp3" "audio/m4a" "audio/mpeg"
-                   "audio/mpga" "audio/mp4" "audio/opus" "audio/pcm" "audio/wav" "audio/webm"
-                   "video/x-flv" "video/quicktime" "video/mpeg" "video/mp4"
-                   "video/webm" "video/wmv" "video/3gpp")
-      :context-window 1048              ; 65536 output token limit
-      :input-cost 0.10
-      :output-cost 0.40
-      :cutoff-date "2025-01")
-     (gemini-2.0-flash
-      :description "Next gen, high speed, multimodal for a diverse variety of tasks"
-      :capabilities (tool-use json media)
-      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                   "application/pdf" "text/plain" "text/csv" "text/html")
-      :context-window 1000
-      :input-cost 0.10
-      :output-cost 0.40
-      :cutoff-date "2024-08")
-     (gemini-2.0-flash-exp
-      :description "Next generation features, superior speed, native tool use"
-      :capabilities (tool-use json media)
-      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                   "application/pdf" "text/plain" "text/csv" "text/html")
-      :context-window 1000
-      :input-cost 0.00
-      :output-cost 0.00)
-     (gemini-2.0-flash-thinking-exp
-      :description "DEPRECATED: Please use gemini-2.0-flash-thinking-exp-01-21 instead"
-      :capabilities (tool-use media)
-      :context-window 32
-      :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
-                   "text/plain" "text/csv" "text/html")
-      :input-cost 0.00
-      :output-cost 0.00)))
+      :cutoff-date "2025-01")))
   "List of available Gemini models and associated properties.
 Keys:
 

--- a/gptel-gh.el
+++ b/gptel-gh.el
@@ -233,7 +233,18 @@
      :context-window 1000
      :input-cost 0.75
      :output-cost 3.75
-     :cutoff-date "2026-03")))
+     :cutoff-date "2026-03")
+    (gemini-3.8-flash
+     :description "Gemini model for long-horizon software engineering, autonomous agents and critical reasoning"
+     :capabilities (tool-use json media audio video)
+     :mime-types ("image/png" "image/jpeg" "image/webp" "image/heic" "image/heif"
+                  "application/pdf" "text/plain" "text/csv" "text/html"
+                  "audio/mpeg" "audio/wav" "audio/ogg" "audio/flac" "audio/aac" "audio/mp3"
+                  "video/mp4" "video/mpeg" "video/avi" "video/quicktime" "video/webm")
+     :context-window 1000
+     :input-cost 0.75
+     :output-cost 3.75
+     :cutoff-date "2026-09")))
 
 (cl-defstruct (gptel--gh (:include gptel-openai)
                          (:copier nil)


### PR DESCRIPTION
Add support for Google's new **Gemini 3.8 Flash** model and update Gemini models according to current deprecations and retirements:

### Changes

1. **Add `gemini-3.8-flash`**:
   - Added to `gptel-gemini.el` (`gptel--gemini-models`) with full specs (1M context window, 65k output limit, multimodal inputs, tool use, pricing notes).
   - Added to `gptel-gh.el` (`gptel--gh-models`).
   - References:
     - Announcement: https://blog.google/innovation-and-ai/models-and-research/gemini-models/3-8-flash-and-3-8-flash-cyber/
     - Model documentation: https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash

2. **Remove Shut Down Models**:
   - Removed retired models whose endpoints have been discontinued according to [Gemini API Deprecations](https://ai.google.dev/gemini-api/docs/deprecations):
     - `gemini-2.0-flash` (shut down June 1, 2026)
     - `gemini-2.0-flash-exp`
     - `gemini-2.0-flash-thinking-exp`
     - `gemini-2.5-pro-preview-06-05` (shut down December 2, 2025)
     - `gemini-2.5-flash-preview-09-2025` (shut down February 17, 2026)
     - `gemini-2.5-flash-lite-preview-09-2025` (shut down March 31, 2026)

3. **Update Deprecation Notices**:
   - `gemini-3.1-flash-lite`: Scheduled for retirement May 7, 2027; updated description to point to `gemini-3.5-flash-lite`.
   - `gemini-3-flash-preview`: Superseded preview model; updated description to point to `gemini-3.6-flash` / `gemini-3.8-flash`.

4. **Documentation**:
   - Updated `NEWS` under **Breaking changes** and **New models and backends**.