### PR TITLE
gptel-ollama: Add gptel-make-llmman backend constructor

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,6 +74,7 @@ gptel uses Curl if available, but falls back to the built-in url-retrieve to wor
       - [[#azure][Azure]]
       - [[#gpt4all][GPT4All]]
       - [[#ollama][Ollama]]
+      - [[#llmman][llmman]]
       - [[#open-webui][Open WebUI]]
       - [[#gemini][Gemini]]
       - [[#llamacpp-or-llamafile][Llama.cpp or Llamafile]]
@@ -206,6 +207,7 @@ gptel supports a number of LLM providers:
 | Anthropic (Claude)   | [[https://www.anthropic.com/api][API key]]                    |
 | Gemini               | [[https://makersuite.google.com/app/apikey][API key]]                    |
 | Ollama               | [[https://ollama.ai/][Ollama running locally]]     |
+| llmman               | [[https://github.com/llmmanorg/llmman][llmman running locally]]     |
 | Open WebUI           | [[https://openwebui.com/][Open WebUI running locally]] |
 | Llama.cpp            | [[https://github.com/ggml-org/llama.cpp/tree/master/tools/server#quick-start][Llama.cpp running locally]]  |
 | Llamafile            | [[https://github.com/Mozilla-Ocho/llamafile#quickstart][Local Llamafile server]]     |
@@ -435,6 +437,37 @@ The above code makes the backend available to select.  If you want it to be the 
                  :host "localhost:11434"
                  :stream t
                  :models '(mistral:latest)))
+#+end_src
+
+#+html: </details>
+
+#+html: <details><summary>
+**** llmman
+#+html: </summary>
+
+[[https://github.com/llmmanorg/llmman][llmman]] is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434.  Register a backend with
+
+#+begin_src emacs-lisp
+(gptel-make-llmman "llmman"             ;Any name of your choosing
+  :stream t                             ;Stream responses
+  :models '(gemma4))                    ;List of models
+#+end_src
+
+This is =gptel-make-ollama= with the host defaulting to =localhost:17434=; pass =:host= if llmman is running elsewhere (see =LLMMAN_HOST=).  Refer to the documentation of =gptel-make-ollama= for more.
+
+You can pick this backend from the menu when using gptel (see [[#usage][Usage]])
+
+***** (Optional) Set as the default gptel backend
+
+The above code makes the backend available to select.  If you want it to be the default backend for gptel, you can set this as the value of =gptel-backend=.  Use this instead of the above.
+
+#+begin_src emacs-lisp
+;; OPTIONAL configuration
+(setq
+ gptel-model 'gemma4
+ gptel-backend (gptel-make-llmman "llmman"
+                 :stream t
+                 :models '(gemma4)))
 #+end_src
 
 #+html: </details>

--- a/gptel-ollama.el
+++ b/gptel-ollama.el
@@ -407,6 +407,23 @@ Example:
                        nil nil #'equal)
                   backend))))
 
+;; llmman
+;;;###autoload
+(cl-defun gptel-make-llmman
+    (name &rest args &key (host "localhost:17434") &allow-other-keys)
+  "Register an llmman backend for gptel with NAME.
+
+llmman (https://github.com/llmmanorg/llmman) serves the Ollama API on
+port 17434, so this is `gptel-make-ollama' with HOST defaulting to
+localhost:17434.  See it for the remaining keyword ARGS.
+
+Example:
+-------
+
+ (gptel-make-llmman \"llmman\" :models \\='(gemma4) :stream t)"
+  (declare (indent 1))
+  (apply #'gptel-make-ollama name :host host args))
+
 (provide 'gptel-ollama)
 ;;; gptel-ollama.el ends here
 

--- a/gptel-request.el
+++ b/gptel-request.el
@@ -450,6 +450,7 @@ constructor functions:
 - `gptel-make-anthropic'
 - `gptel-make-gemini'
 - `gptel-make-ollama'
+- `gptel-make-llmman'
 - `gptel-make-azure'
 - `gptel-make-gpt4all'
 - `gptel-make-kagi'


### PR DESCRIPTION
[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434.

- `gptel-ollama.el`: new autoloaded `gptel-make-llmman`, a thin wrapper that calls `gptel-make-ollama` with `:host` defaulting to `localhost:17434`. No new struct; the returned backend is a `gptel-ollama`, same as `gptel-make-gpt4all` reuses `gptel-make-openai`.
- `gptel-request.el`: list `gptel-make-llmman` in the `gptel-backend` docstring.
- `README.org`: add llmman to the provider table, TOC and a setup section after Ollama.

**Testing:** Byte-compiled with Emacs 31.1 (`-Q --batch`), only the pre-existing `provided-mode-derived-p` warning; `(gptel-make-llmman "llmman" :stream t :models '(gemma4))` returns a `gptel-ollama` backend with url `http://localhost:17434/api/chat`.

> AI-assisted, reviewed before submitting.
